### PR TITLE
feat: AWS EC2 단일 인스턴스 배포 구조 적용

### DIFF
--- a/.kiro/specs/book-discussion-website/design.md
+++ b/.kiro/specs/book-discussion-website/design.md
@@ -14,41 +14,92 @@
 
 ## 아키텍처
 
+### 배포 아키텍처: AWS EC2 단일 인스턴스
+
+모든 서비스(Nginx, Node.js, MySQL)를 하나의 EC2 인스턴스에서 운영하는 단일 서버 구조를 채택한다. MVP 단계에서 운영 복잡도를 최소화하고 비용을 절감하기 위한 선택이다.
+
+#### EC2 인스턴스 사양
+
+| 항목 | 권장 사양 |
+|------|----------|
+| 인스턴스 타입 | t3.small (2 vCPU, 2GB RAM) 이상 |
+| OS | Ubuntu 22.04 LTS |
+| 스토리지 | EBS gp3 30GB 이상 |
+| 리전 | ap-northeast-2 (서울) |
+
+#### 보안 그룹 설정
+
+| 규칙 | 프로토콜 | 포트 | 소스 | 설명 |
+|------|---------|------|------|------|
+| 인바운드 | TCP | 80 | 0.0.0.0/0 | HTTP |
+| 인바운드 | TCP | 443 | 0.0.0.0/0 | HTTPS (SSL 적용 시) |
+| 인바운드 | TCP | 22 | 관리자 IP | SSH 접속 |
+| 아웃바운드 | 전체 | 전체 | 0.0.0.0/0 | 외부 API 호출 등 |
+
+> MySQL(3306)은 외부에 노출하지 않으며, localhost에서만 접근 가능하도록 설정한다.
+
 ### 시스템 구성도
 
 ```mermaid
 graph TB
-    subgraph Client["프론트엔드 (React SPA)"]
-        Pages[페이지 컴포넌트]
-        Store[상태 관리]
-        API_Client[API 클라이언트]
-    end
+    User[사용자 브라우저]
 
-    subgraph Server["백엔드 (Node.js + Express)"]
-        Router[라우터]
-        Auth_MW[인증 미들웨어]
-        Controllers[컨트롤러]
-        Services[서비스 레이어]
-        Validators[입력 검증]
+    subgraph EC2["AWS EC2 인스턴스 (t3.small)"]
+        subgraph Nginx_Block["Nginx (리버스 프록시)"]
+            Nginx["포트 80/443<br/>정적 파일 캐싱<br/>gzip 압축"]
+        end
+
+        subgraph Node_Block["Node.js 앱 (PM2 관리)"]
+            Express["Express 서버<br/>포트 3000"]
+            StaticServe["React 빌드 정적 파일 서빙"]
+            Router[라우터]
+            Auth_MW[인증 미들웨어]
+            Services[서비스 레이어]
+            Validators[입력 검증]
+        end
+
+        subgraph DB_Block["MySQL"]
+            MySQL[("MySQL<br/>포트 3306<br/>localhost만 접근")]
+        end
     end
 
     subgraph External["외부 서비스"]
         BookAPI[책 검색 API<br/>카카오/네이버]
+        LetsEncrypt[Let's Encrypt<br/>SSL 인증서]
     end
 
-    subgraph DB["데이터베이스"]
-        MySQL[(MySQL)]
-    end
-
-    Pages --> Store
-    Store --> API_Client
-    API_Client -->|HTTP/REST| Router
+    User -->|HTTP/HTTPS| Nginx
+    Nginx -->|프록시 패스| Express
+    Express --> StaticServe
+    Express --> Router
     Router --> Auth_MW
-    Auth_MW --> Controllers
-    Controllers --> Services
+    Auth_MW --> Services
     Services --> Validators
     Services --> MySQL
     Services -->|책 검색| BookAPI
+    Nginx -.->|SSL 인증서| LetsEncrypt
+```
+
+### EC2 내부 서비스 흐름
+
+```mermaid
+sequenceDiagram
+    participant B as 브라우저
+    participant N as Nginx (:80/:443)
+    participant E as Express (:3000)
+    participant M as MySQL (:3306)
+
+    B->>N: GET / (페이지 요청)
+    N->>E: 프록시 패스
+    E-->>N: React 빌드 HTML/JS/CSS
+    N-->>B: 정적 파일 응답 (gzip)
+
+    B->>N: POST /api/auth/login
+    N->>E: 프록시 패스 /api/*
+    E->>M: 사용자 조회
+    M-->>E: 사용자 데이터
+    E-->>N: JWT 토큰 응답
+    N-->>B: 로그인 성공
 ```
 
 ### 기술 스택
@@ -60,11 +111,47 @@ graph TB
 | HTTP 클라이언트 | Axios | 인터셉터 기반 토큰 관리 |
 | 백엔드 | Node.js + Express + TypeScript | 빠른 개발, 프론트엔드와 언어 통일 |
 | ORM | Prisma | 타입 안전한 DB 접근, 마이그레이션 지원 |
-| 데이터베이스 | MySQL | 관계형 데이터 모델에 적합, 널리 사용되는 RDBMS |
+| 데이터베이스 | MySQL (EC2 내 직접 설치) | 관계형 데이터 모델에 적합, 단일 서버 운영 |
+| 웹서버 | Nginx | 리버스 프록시, 정적 파일 캐싱, gzip 압축 |
+| 프로세스 관리 | PM2 | Node.js 프로세스 자동 재시작, 로그 관리 |
+| SSL | Let's Encrypt (선택) | 무료 SSL 인증서, certbot 자동 갱신 |
 | 인증 | JWT (Access + Refresh Token) | 무상태 인증, 확장성 |
 | 비밀번호 해싱 | bcrypt | 업계 표준 |
 | 입력 검증 | Zod | TypeScript 네이티브 스키마 검증 |
 | 테스트 | Vitest + fast-check | 단위 테스트 + 속성 기반 테스트 |
+
+### 배포 절차 개요
+
+1. EC2 인스턴스 생성 및 보안 그룹 설정
+2. 서버 환경 구성: Node.js, MySQL, Nginx, PM2 설치
+3. MySQL 데이터베이스 및 사용자 생성
+4. 소스 코드 배포 (git clone 또는 scp)
+5. `client/` 디렉토리에서 React 빌드 (`npm run build`) → 빌드 결과물을 Express에서 정적 서빙
+6. `server/` 디렉토리에서 Prisma 마이그레이션 실행 (`npx prisma migrate deploy`)
+7. PM2로 Node.js 서버 시작 (`pm2 start server/dist/index.js`)
+8. Nginx 설정: 포트 80 → localhost:3000 프록시 패스
+9. (선택) certbot으로 Let's Encrypt SSL 인증서 발급 및 HTTPS 설정
+
+### Nginx 설정 예시
+
+```nginx
+server {
+    listen 80;
+    server_name your-domain.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+```
 
 ### 인증 흐름
 

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -1,8 +1,9 @@
 import axios from 'axios';
 import { useAuthStore } from '../stores/authStore';
 
+// 프로덕션에서는 같은 origin, 개발에서는 Vite proxy 사용 → 상대 경로로 통일
 const apiClient = axios.create({
-  baseURL: 'http://127.0.0.1:3000/api',
+  baseURL: '/api',
   headers: {
     'Content-Type': 'application/json',
   },

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  build: {
+    outDir: 'dist',
+  },
   server: {
     port: 5173,
     proxy: {

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  apps: [{
+    name: 'book-discussion',
+    script: 'server/dist/index.js',
+    env: {
+      NODE_ENV: 'production',
+      PORT: 3000,
+    },
+    instances: 1,
+    autorestart: true,
+    watch: false,
+    max_memory_restart: '500M',
+  }],
+};

--- a/nginx/book-discussion.conf
+++ b/nginx/book-discussion.conf
@@ -1,0 +1,21 @@
+server {
+    listen 80;
+    server_name your-domain.com;  # 실제 도메인 또는 EC2 퍼블릭 IP로 변경
+
+    # gzip 압축
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml;
+    gzip_min_length 256;
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+}

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,13 @@
+# EC2 프로덕션 환경 설정 예시
+NODE_ENV=production
+PORT=3000
+
+# MySQL (EC2 로컬)
+DATABASE_URL="mysql://bookuser:your_password@localhost:3306/book_discussion"
+
+# JWT
+JWT_SECRET=your_jwt_secret_here
+JWT_REFRESH_SECRET=your_jwt_refresh_secret_here
+
+# 책 검색 API (카카오)
+KAKAO_REST_API_KEY=your_kakao_api_key

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
+import path from 'path';
 import authRouter from './routes/auth.routes';
 import bookRouter from './routes/book.routes';
 import groupRouter from './routes/group.routes';
@@ -11,11 +12,18 @@ import { globalErrorHandler } from './middleware/errorHandler';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+const isProduction = process.env.NODE_ENV === 'production';
 
-app.use(cors({
-  origin: ['http://localhost:5173', 'http://127.0.0.1:5173'],
-  credentials: true
-}));
+// CORS: 개발 환경에서만 Vite dev server 허용, 프로덕션에서는 같은 origin
+if (isProduction) {
+  app.use(cors({ credentials: true }));
+} else {
+  app.use(cors({
+    origin: ['http://localhost:5173', 'http://127.0.0.1:5173'],
+    credentials: true
+  }));
+}
+
 app.use(express.json());
 
 app.get('/api/health', (_req, res) => {
@@ -33,8 +41,17 @@ app.use('/api/me', mypageRouter);
 // 글로벌 에러 핸들러 (모든 라우터 뒤에 등록)
 app.use(globalErrorHandler);
 
+// 프로덕션: React 빌드 정적 파일 서빙 + SPA fallback
+if (isProduction) {
+  const clientDistPath = path.join(__dirname, '../../client/dist');
+  app.use(express.static(clientDistPath));
+  app.get('*', (_req, res) => {
+    res.sendFile(path.join(clientDistPath, 'index.html'));
+  });
+}
+
 app.listen(PORT, () => {
-  console.log(`Server is running on 127.0.0.1:${PORT}`);
+  console.log(`Server is running on 127.0.0.1:${PORT} (${isProduction ? 'production' : 'development'})`);
 });
 
 export default app;


### PR DESCRIPTION
# 2025-04-27 변경 내역: AWS EC2 배포 구조 적용

## 목적
독서 토론 웹사이트를 AWS EC2 단일 인스턴스(Nginx + Node.js + MySQL)에서 운영할 수 있도록 코드 및 설정 수정

## 코드 변경

### 1. `server/src/index.ts`
- `path` 모듈 import 추가
- `NODE_ENV` 기반 프로덕션/개발 환경 분기 추가
- CORS: 프로덕션에서는 같은 origin 허용, 개발에서는 Vite dev server(5173) 허용
- 프로덕션 모드에서 `client/dist` 정적 파일 서빙 (`express.static`)
- SPA fallback: API 외 모든 경로에서 `index.html` 반환 (`app.get('*')`)

### 2. `client/src/api/client.ts`
- `baseURL`을 `http://127.0.0.1:3000/api` → `/api` (상대 경로)로 변경
- 개발: Vite proxy가 `/api` → `localhost:3000`으로 프록시
- 프로덕션: 같은 Express 서버에서 서빙되므로 상대 경로로 동작

### 3. `client/vite.config.ts`
- `build.outDir: 'dist'` 명시 추가

## 새로 추가한 파일

### 4. `ecosystem.config.js`
- PM2 프로세스 관리 설정
- `NODE_ENV=production`, 포트 3000, 자동 재시작, 메모리 제한 500MB

### 5. `server/.env.example`
- EC2 프로덕션 환경변수 템플릿
- DATABASE_URL (MySQL localhost), JWT 시크릿, 카카오 API 키

### 6. `nginx/book-discussion.conf`
- Nginx 리버스 프록시 설정 (포트 80 → 127.0.0.1:3000)
- gzip 압축 활성화
- 프록시 헤더 설정 (X-Real-IP, X-Forwarded-For 등)

## 참고
- 로컬 개발 환경(`npm run dev`)은 기존과 동일하게 동작
- design.md도 AWS EC2 단일 인스턴스 아키텍처에 맞게 업데이트 완료
