### PR TITLE
fix: 메모 기능 버그 수정 - 읽지 않은 페이지 메모 작성 제한 추가 - 최근 메모 목록에서 비공개 메모 필터링

### DIFF
--- a/server/src/services/group.service.ts
+++ b/server/src/services/group.service.ts
@@ -148,7 +148,13 @@ export const groupService = {
 
     if (isMember) {
       recentMemos = await prisma.memo.findMany({
-        where: { groupId },
+        where: {
+          groupId,
+          OR: [
+            { userId },
+            { isPublic: true },
+          ],
+        },
         orderBy: { createdAt: 'desc' },
         take: 5,
         include: {

--- a/server/src/services/memo.service.ts
+++ b/server/src/services/memo.service.ts
@@ -14,6 +14,10 @@ export const memoService = {
       throw new AppError(403, 'FORBIDDEN', '모임 참여자만 메모를 작성할 수 있습니다');
     }
 
+    if (data.pageEnd > member.readingProgress) {
+      throw new AppError(400, 'INVALID_PAGE_RANGE', `아직 읽지 않은 페이지입니다. 현재 읽은 페이지: ${member.readingProgress}`);
+    }
+
     const memo = await prisma.memo.create({
       data: {
         groupId,


### PR DESCRIPTION
## 📝 PR 요약
<!-- 이 PR의 목적과 주요 변경 사항을 간략하게 설명해 주세요. -->
메모 기능의 두가지 버그 수정
사용자가 아직 읽지 않은 페이지 범위에도 메모를 작성할 수 있던 문제 → 메모 생성 시 pageEnd가 사용자의 readingProgress를 초과하면 요청을 거부하도록 검증 추가
그룹 상세 페이지의 "최근 메모" 항목에 다른 사용자의 비공개 메모까지 노출되던 문제 → 본인 메모이거나 공개 메모만 조회되도록 필터 추가

## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 적어주세요. 이슈를 자동으로 닫으려면 'Resolves #이슈번호' 형태로 작성하세요. -->
- Resolves: #2 

## 🏷️ PR 분류
<!-- 해당되는 항목의 [ ] 안에 x를 입력하여 [x]로 만들어 주세요. -->
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ✨ 새로운 기능 추가 (New Feature)
- [ ] 🛠️ 코드 리팩토링 (Refactoring)
- [ ] 📚 문서 수정 (Documentation)
- [ ] ⚙️ 설정/빌드 환경 수정 (Configuration/Build)
- [ ] 🧹 단순 수정 (기능에 영향을 주지 않는 오타 수정, 포맷팅 등)

## 🧪 테스트 방법
<!-- 변경 사항이 정상적으로 동작하는지 확인하기 위해 진행한 테스트 방법과 결과를 설명해 주세요. -->

## 📸 스크린샷 또는 GIF (선택 사항)
<!-- UI 변경 사항이나 시각적으로 확인할 수 있는 결과물이 있다면 첨부해 주세요. -->
