### PR TITLE
카카오 로그인 엔드포인트 하드코딩 제거, 호스트 기반 자동 판단으로 변경

### DIFF
--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -205,7 +205,7 @@ function LoginPage() {
         <div style={{ margin: '16px 0', textAlign: 'center' as const, color: '#a0aec0', fontSize: 13 }}>또는</div>
 
         <a
-          href="http://localhost:3000/api/auth/kakao"
+          href="/api/auth/kakao"
           style={{
             display: 'block',
             width: '100%',

--- a/server/src/routes/auth.routes.ts
+++ b/server/src/routes/auth.routes.ts
@@ -119,8 +119,14 @@ router.get('/kakao', (_req: Request, res: Response) => {
 router.get('/kakao/callback', async (req: Request, res: Response) => {
   try {
     const { code } = req.query;
+    // 프론트엔드 URL 자동 결정: 개발은 5173, 배포는 같은 호스트
+    const host = req.get('host') || 'localhost:3000';
+    const protocol = req.protocol;
+    const isDev = host.includes('localhost') || host.includes('127.0.0.1');
+    const frontendUrl = isDev ? `${protocol}://${host.replace(':3000', ':5173')}` : `${protocol}://${host}`;
+
     if (!code || typeof code !== 'string') {
-      res.redirect('http://localhost:5173/login?error=kakao_failed');
+      res.redirect(`${frontendUrl}/login?error=kakao_failed`);
       return;
     }
 
@@ -149,11 +155,14 @@ router.get('/kakao/callback', async (req: Request, res: Response) => {
     const kakaoAccessToken = tokenRes.data.access_token;
     const result = await authService.kakaoLogin(kakaoAccessToken);
 
-    // 프론트엔드로 토큰 전달 (URL 파라미터)
-    res.redirect(`http://localhost:5173/login?accessToken=${result.accessToken}&refreshToken=${result.refreshToken}&isNew=${result.isNew}`);
+    res.redirect(`${frontendUrl}/login?accessToken=${result.accessToken}&refreshToken=${result.refreshToken}&isNew=${result.isNew}`);
   } catch (err) {
     console.error('Kakao login error:', err);
-    res.redirect('http://localhost:5173/login?error=kakao_failed');
+    const host = req.get('host') || 'localhost:3000';
+    const protocol = req.protocol;
+    const isDev = host.includes('localhost') || host.includes('127.0.0.1');
+    const frontendUrl = isDev ? `${protocol}://${host.replace(':3000', ':5173')}` : `${protocol}://${host}`;
+    res.redirect(`${frontendUrl}/login?error=kakao_failed`);
   }
 });
 


### PR DESCRIPTION
## 📝 PR 요약
<!-- 이 PR의 목적과 주요 변경 사항을 간략하게 설명해 주세요. -->
서버에서 카카오소셜 로그인 가능하게 하려했으나 고정된 배포 주소가 없어서 아직은 해결불가, 하드코딩된 주소를 수정
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 적어주세요. 이슈를 자동으로 닫으려면 'Resolves #이슈번호' 형태로 작성하세요. -->
- Resolves: #

## 🏷️ PR 분류
<!-- 해당되는 항목의 [ ] 안에 x를 입력하여 [x]로 만들어 주세요. -->
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ✨ 새로운 기능 추가 (New Feature)
- [ ] 🛠️ 코드 리팩토링 (Refactoring)
- [ ] 📚 문서 수정 (Documentation)
- [ ] ⚙️ 설정/빌드 환경 수정 (Configuration/Build)
- [x] 🧹 단순 수정 (기능에 영향을 주지 않는 오타 수정, 포맷팅 등)

## 🧪 테스트 방법
<!-- 변경 사항이 정상적으로 동작하는지 확인하기 위해 진행한 테스트 방법과 결과를 설명해 주세요. -->

## 📸 스크린샷 또는 GIF (선택 사항)
<!-- UI 변경 사항이나 시각적으로 확인할 수 있는 결과물이 있다면 첨부해 주세요. -->
