### PR TITLE
feat: 토론 주제 제안/개최 시스템 분리 (#45) - TopicProposal 모델 추가

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,8 +8,10 @@
       "name": "book-discussion-client",
       "version": "0.0.1",
       "dependencies": {
+        "@types/multer": "^2.1.0",
         "axios": "^1.7.7",
         "marked": "^18.0.3",
+        "multer": "^2.1.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.28.0",
@@ -1210,11 +1212,59 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "license": "MIT"
     },
     "node_modules/@types/marked": {
@@ -1224,11 +1274,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
+      "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
       "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -1239,6 +1297,18 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -1262,6 +1332,25 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -1282,6 +1371,12 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -1347,6 +1442,23 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1391,6 +1503,21 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/convert-source-map": {
@@ -1728,6 +1855,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1803,6 +1936,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -1830,6 +1972,25 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -1982,6 +2143,20 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
@@ -2027,6 +2202,26 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -2056,6 +2251,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -2072,6 +2284,25 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.6.3",
@@ -2091,7 +2322,6 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -2124,6 +2354,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.4.2",

--- a/client/package.json
+++ b/client/package.json
@@ -10,8 +10,10 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@types/multer": "^2.1.0",
     "axios": "^1.7.7",
     "marked": "^18.0.3",
+    "multer": "^2.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,6 +11,7 @@ import MyPage from './pages/MyPage';
 import SettingsPage from './pages/SettingsPage';
 import DashboardPage from './pages/DashboardPage';
 import InvitePage from './pages/InvitePage';
+import ProposalThreadPage from './pages/ProposalThreadPage';
 
 function App() {
   return (
@@ -27,6 +28,7 @@ function App() {
       <Route path="/settings" element={<SettingsPage />} />
       <Route path="/groups/:id/dashboard" element={<DashboardPage />} />
       <Route path="/invite/:code" element={<InvitePage />} />
+      <Route path="/proposals/:id" element={<ProposalThreadPage />} />
     </Routes>
   );
 }

--- a/client/src/api/proposals.ts
+++ b/client/src/api/proposals.ts
@@ -1,0 +1,40 @@
+import apiClient from './client';
+
+export interface TopicProposal {
+  id: string;
+  groupId: string;
+  authorId: string;
+  title: string;
+  content?: string;
+  memoId?: string;
+  status: 'proposed' | 'opened';
+  createdAt: string;
+  author: { id: string; nickname: string };
+  commentCount?: number;
+}
+
+export const proposalsApi = {
+  list: (groupId: string) =>
+    apiClient.get<TopicProposal[]>(`/groups/${groupId}/proposals`),
+
+  create: (groupId: string, data: { title: string; content?: string; memoId?: string }) =>
+    apiClient.post<TopicProposal>(`/groups/${groupId}/proposals`, data),
+
+  openDiscussion: (proposalId: string) =>
+    apiClient.post(`/proposals/${proposalId}/open`),
+
+  delete: (proposalId: string) =>
+    apiClient.delete(`/proposals/${proposalId}`),
+
+  getComments: (proposalId: string) =>
+    apiClient.get<any[]>(`/proposals/${proposalId}/comments`),
+
+  addComment: (proposalId: string, content: string) =>
+    apiClient.post(`/proposals/${proposalId}/comments`, { content }),
+
+  addReply: (commentId: string, content: string) =>
+    apiClient.post(`/proposal-comments/${commentId}/replies`, { content }),
+
+  getById: (proposalId: string) =>
+    apiClient.get<TopicProposal>(`/proposals/${proposalId}`),
+};

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -2,16 +2,16 @@ import { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { dashboardApi, type Announcement, type DiscussionSchedule } from '../api/dashboard';
 import { groupsApi } from '../api/groups';
-import { discussionsApi } from '../api/discussions';
+import { proposalsApi, type TopicProposal } from '../api/proposals';
 import { useAuthStore } from '../stores/authStore';
-import type { GroupDetail, RecommendedTopic } from '../types';
+import type { GroupDetail } from '../types';
 
 const tabs = [
   { id: 'calendar', label: '📅 토론 일정' },
   { id: 'invite', label: '🔗 초대 링크' },
   { id: 'announcements', label: '📢 공지사항' },
   { id: 'members', label: '👥 멤버 관리' },
-  { id: 'topics', label: '💡 추천 주제' },
+  { id: 'topics', label: '💬 토론 생성' },
 ] as const;
 
 type TabId = typeof tabs[number]['id'];
@@ -36,7 +36,6 @@ const styles: Record<string, React.CSSProperties> = {
   inviteBox: { backgroundColor: '#f7fafc', padding: '12px 16px', borderRadius: 6, display: 'flex', alignItems: 'center', gap: 12 },
   calGrid: { display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 2, textAlign: 'center' as const },
   calCell: { padding: '8px 4px', fontSize: 12, borderRadius: 4, minHeight: 36, display: 'flex', alignItems: 'center', justifyContent: 'center' },
-  recCard: { backgroundColor: '#f0fff4', padding: '12px 16px', borderRadius: 6, marginBottom: 8 },
 };
 
 function DashboardPage() {
@@ -50,7 +49,7 @@ function DashboardPage() {
   const [inviteExpiresAt, setInviteExpiresAt] = useState<string | null>(null);
   const [announcements, setAnnouncements] = useState<Announcement[]>([]);
   const [schedules, setSchedules] = useState<DiscussionSchedule[]>([]);
-  const [recommendations, setRecommendations] = useState<RecommendedTopic[]>([]);
+  const [proposals, setProposals] = useState<TopicProposal[]>([]);
   const [newAnnTitle, setNewAnnTitle] = useState('');
   const [newAnnContent, setNewAnnContent] = useState('');
   const [newSchedTitle, setNewSchedTitle] = useState('');
@@ -67,19 +66,19 @@ function DashboardPage() {
   const fetchAll = async () => {
     if (!groupId) return;
     try {
-      const [gRes, invRes, annRes, recRes, schedRes] = await Promise.all([
+      const [gRes, invRes, annRes, schedRes, propRes] = await Promise.all([
         groupsApi.getDetail(groupId),
         dashboardApi.getInviteCode(groupId).catch(() => ({ data: { inviteCode: null, expiresAt: null } })),
         dashboardApi.listAnnouncements(groupId).catch(() => ({ data: [] })),
-        discussionsApi.getRecommendations(groupId).catch(() => ({ data: [] })),
         dashboardApi.listSchedules(groupId).catch(() => ({ data: [] })),
+        proposalsApi.list(groupId).catch(() => ({ data: [] })),
       ]);
       setGroup(gRes.data);
       setInviteCode(invRes.data.inviteCode);
       setInviteExpiresAt(invRes.data.expiresAt || null);
       setAnnouncements(annRes.data);
-      setRecommendations(recRes.data);
       setSchedules(schedRes.data);
+      setProposals(propRes.data);
     } catch {}
   };
 
@@ -117,10 +116,14 @@ function DashboardPage() {
     await dashboardApi.deleteAnnouncement(groupId, annId); fetchAll();
   };
 
-  const handleSelectRecommendation = async (rec: RecommendedTopic) => {
-    if (!groupId) return;
-    await discussionsApi.create(groupId, { title: rec.title, content: rec.content });
-    alert('토론 스레드가 생성되었습니다'); fetchAll();
+  const handleOpenDiscussion = async (proposalId: string) => {
+    if (!confirm('이 주제로 토론을 개최하시겠습니까?')) return;
+    try {
+      await proposalsApi.openDiscussion(proposalId);
+      alert('토론이 개최되었습니다'); fetchAll();
+    } catch (err: any) {
+      alert(err.response?.data?.error?.message || '토론 개최에 실패했습니다');
+    }
   };
 
   const handleCreateSchedule = async () => {
@@ -274,16 +277,32 @@ function DashboardPage() {
       case 'topics':
         return (
           <div style={styles.section}>
-            <div style={styles.sectionTitle}>💡 AI 추천 토론 주제</div>
-            {recommendations.length === 0 ? (
-              <div style={{ color: '#a0aec0', fontSize: 13 }}>공개 메모가 2개 이상이면 추천 주제가 생성됩니다</div>
-            ) : recommendations.map((rec, i) => (
-              <div key={i} style={styles.recCard}>
-                <div style={{ fontWeight: 600, fontSize: 14, marginBottom: 4 }}>{rec.title}</div>
-                <div style={{ fontSize: 13, color: '#4a5568', marginBottom: 8 }}>{rec.content}</div>
-                <button style={{ ...styles.btn, ...styles.btnPrimary, padding: '6px 14px', fontSize: 12 }} onClick={() => handleSelectRecommendation(rec)}>이 주제로 토론 열기</button>
+            <div style={styles.sectionTitle}>💬 토론 생성</div>
+            <div style={{ fontSize: 13, color: '#718096', marginBottom: 16 }}>참여자들이 제안한 주제 중 선택하여 토론을 개최합니다.</div>
+
+            {proposals.filter(p => p.status === 'proposed').length === 0 ? (
+              <div style={{ color: '#a0aec0', fontSize: 13 }}>아직 제안된 토론 주제가 없습니다</div>
+            ) : proposals.filter(p => p.status === 'proposed').map(p => (
+              <div key={p.id} style={{ padding: '12px 16px', borderBottom: '1px solid #f0f0f0', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: 14, fontWeight: 500, color: '#2d3748' }}>{p.title}</div>
+                  {p.content && <div style={{ fontSize: 13, color: '#4a5568', marginTop: 4 }}>{p.content.slice(0, 100)}{p.content.length > 100 ? '...' : ''}</div>}
+                  <div style={{ fontSize: 12, color: '#a0aec0', marginTop: 4 }}>{p.author.nickname} · {new Date(p.createdAt).toLocaleDateString()}</div>
+                </div>
+                <button style={{ ...styles.btn, ...styles.btnPrimary, padding: '6px 14px', fontSize: 12 }} onClick={() => handleOpenDiscussion(p.id)}>토론 개최</button>
               </div>
             ))}
+
+            {proposals.filter(p => p.status === 'opened').length > 0 && (
+              <div style={{ marginTop: 20 }}>
+                <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 8, color: '#48bb78' }}>✅ 개최된 토론</div>
+                {proposals.filter(p => p.status === 'opened').map(p => (
+                  <div key={p.id} style={{ padding: '8px 0', borderBottom: '1px solid #f0f0f0', fontSize: 13, color: '#718096' }}>
+                    {p.title} — {p.author.nickname}
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         );
     }

--- a/client/src/pages/DiscussionsPage.tsx
+++ b/client/src/pages/DiscussionsPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, type FormEvent } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { discussionsApi } from '../api/discussions';
+import { proposalsApi, type TopicProposal } from '../api/proposals';
 import { memosApi } from '../api/memos';
 import { aiApi, type AiTopic } from '../api/ai';
 import { useAuthStore } from '../stores/authStore';
@@ -241,6 +242,7 @@ function DiscussionsPage() {
   const accessToken = useAuthStore((s) => s.accessToken);
 
   const [discussions, setDiscussions] = useState<Discussion[]>([]);
+  const [proposals, setProposals] = useState<TopicProposal[]>([]);
   const [recommendations, setRecommendations] = useState<RecommendedTopic[]>([]);
   const [aiTopics, setAiTopics] = useState<AiTopic[]>([]);
   const [aiLoading, setAiLoading] = useState(false);
@@ -272,14 +274,16 @@ function DiscussionsPage() {
     setLoading(true);
     try {
       const params = filterMine && currentUserId ? { authorId: currentUserId } : undefined;
-      const [discRes, recRes, memoRes] = await Promise.all([
+      const [discRes, recRes, memoRes, propRes] = await Promise.all([
         discussionsApi.listByGroup(groupId!, params),
         discussionsApi.getRecommendations(groupId!).catch(() => ({ data: [] as RecommendedTopic[] })),
         memosApi.listByGroup(groupId!).catch(() => ({ data: { myMemos: [] as Memo[], publicMemos: [] as Memo[] } })),
+        proposalsApi.list(groupId!).catch(() => ({ data: [] as TopicProposal[] })),
       ]);
       setDiscussions(discRes.data);
       setRecommendations(recRes.data);
       setMyMemos(memoRes.data.myMemos || []);
+      setProposals(propRes.data);
     } catch {
       setDiscussions([]);
     } finally {
@@ -313,7 +317,7 @@ function DiscussionsPage() {
 
     setSubmitting(true);
     try {
-      await discussionsApi.create(groupId!, {
+      await proposalsApi.create(groupId!, {
         title: formTitle.trim(),
         content: formContent.trim() || undefined,
         memoId: formMemoId || undefined,
@@ -402,13 +406,43 @@ function DiscussionsPage() {
         </button>
       </div>
 
-      {/* Discussion List */}
+      {/* 토론 주제 목록 (제안된 주제) */}
       <div style={styles.section}>
         <div style={styles.sectionTitle}>토론 주제 목록</div>
         {loading ? (
           <div style={styles.emptyState}>불러오는 중...</div>
+        ) : proposals.length === 0 ? (
+          <div style={styles.emptyState}>제안된 토론 주제가 없습니다</div>
+        ) : (
+          proposals.map((p) => (
+            <div
+              key={p.id}
+              style={{ ...styles.discussionItem, cursor: 'pointer' }}
+              onClick={() => navigate(`/proposals/${p.id}`)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => e.key === 'Enter' && navigate(`/proposals/${p.id}`)}
+            >
+              <div style={styles.discussionTitle}>
+                {p.title}
+                {p.status === 'opened' && <span style={{ ...styles.recommendedBadge, backgroundColor: '#c6f6d5', color: '#276749' }}>개최됨</span>}
+              </div>
+              {p.content && <div style={{ fontSize: 13, color: '#4a5568', marginTop: 2, marginBottom: 4 }}>{p.content.slice(0, 100)}{p.content.length > 100 ? '...' : ''}</div>}
+              <div style={styles.discussionMeta}>
+                {p.author.nickname} · {new Date(p.createdAt).toLocaleDateString()}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* 열린 토론 목록 */}
+      <div style={styles.section}>
+        <div style={styles.sectionTitle}>열린 토론 목록</div>
+        {loading ? (
+          <div style={styles.emptyState}>불러오는 중...</div>
         ) : discussions.length === 0 ? (
-          <div style={styles.emptyState}>토론 주제가 없습니다</div>
+          <div style={styles.emptyState}>아직 개최된 토론이 없습니다</div>
         ) : (
           discussions.map((d) => (
             <div
@@ -425,7 +459,6 @@ function DiscussionsPage() {
               </div>
               <div style={styles.discussionMeta}>
                 {d.authorNickname} · {new Date(d.createdAt).toLocaleDateString()}
-                {d.memoId && ' · 📝 메모 연결됨'}
               </div>
             </div>
           ))

--- a/client/src/pages/ProposalThreadPage.tsx
+++ b/client/src/pages/ProposalThreadPage.tsx
@@ -1,0 +1,211 @@
+import { useState, useEffect, type FormEvent } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { proposalsApi, type TopicProposal } from '../api/proposals';
+import { useAuthStore } from '../stores/authStore';
+import { timeAgo } from '../utils/timeAgo';
+
+interface Comment {
+  id: string;
+  authorId: string;
+  content: string;
+  createdAt: string;
+  author: { id: string; nickname: string };
+  replies: Reply[];
+}
+
+interface Reply {
+  id: string;
+  authorId: string;
+  content: string;
+  createdAt: string;
+  author: { id: string; nickname: string };
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  container: { maxWidth: 800, margin: '0 auto', padding: '24px 16px' },
+  backLink: { display: 'inline-block', marginBottom: 16, fontSize: 14, color: '#3182ce' },
+  topicSection: { backgroundColor: '#fff', borderRadius: 8, padding: 20, boxShadow: '0 1px 4px rgba(0,0,0,0.08)', marginBottom: 16 },
+  topicTitle: { fontSize: 22, fontWeight: 700, marginBottom: 8, color: '#2d3748' },
+  topicContent: { fontSize: 14, color: '#4a5568', lineHeight: 1.6, marginBottom: 12 },
+  topicMeta: { fontSize: 12, color: '#a0aec0' },
+  section: { backgroundColor: '#fff', borderRadius: 8, padding: 20, boxShadow: '0 1px 4px rgba(0,0,0,0.08)', marginBottom: 16 },
+  sectionTitle: { fontSize: 16, fontWeight: 600, marginBottom: 12, color: '#2d3748' },
+  commentCard: { padding: '12px 0', borderBottom: '1px solid #f0f0f0' },
+  commentAuthor: { fontSize: 14, fontWeight: 600, color: '#2d3748', marginBottom: 4 },
+  commentContent: { fontSize: 14, color: '#4a5568', lineHeight: 1.6, marginBottom: 4 },
+  commentMeta: { fontSize: 12, color: '#a0aec0', marginBottom: 8 },
+  replySection: { marginLeft: 24, paddingLeft: 12, borderLeft: '2px solid #e2e8f0' },
+  replyCard: { padding: '8px 0' },
+  replyAuthor: { fontSize: 13, fontWeight: 600, color: '#4a5568', marginBottom: 2 },
+  replyContent: { fontSize: 13, color: '#4a5568', lineHeight: 1.5 },
+  replyMeta: { fontSize: 11, color: '#a0aec0', marginTop: 2 },
+  formRow: { display: 'flex', gap: 8, marginTop: 8 },
+  input: { flex: 1, padding: '8px 12px', fontSize: 14, border: '1px solid #ddd', borderRadius: 4, boxSizing: 'border-box' as const },
+  submitBtn: { padding: '8px 16px', backgroundColor: '#3182ce', color: '#fff', border: 'none', borderRadius: 4, fontSize: 13, fontWeight: 500, cursor: 'pointer', whiteSpace: 'nowrap' as const },
+  replyToggle: { fontSize: 12, color: '#3182ce', cursor: 'pointer', background: 'none', border: 'none', padding: 0 },
+  emptyState: { textAlign: 'center' as const, padding: '30px 20px', color: '#a0aec0', fontSize: 14 },
+  loading: { textAlign: 'center' as const, padding: '60px 20px', color: '#a0aec0' },
+};
+
+function ProposalThreadPage() {
+  const { id: proposalId } = useParams<{ id: string }>();
+  const user = useAuthStore((s) => s.user);
+  const accessToken = useAuthStore((s) => s.accessToken);
+
+  const [proposal, setProposal] = useState<TopicProposal | null>(null);
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const [newComment, setNewComment] = useState('');
+  const [submittingComment, setSubmittingComment] = useState(false);
+
+  const [replyingTo, setReplyingTo] = useState<string | null>(null);
+  const [replyContent, setReplyContent] = useState('');
+  const [submittingReply, setSubmittingReply] = useState(false);
+
+  let currentUserId = user?.id || '';
+  if (!currentUserId && accessToken) {
+    try { currentUserId = JSON.parse(atob(accessToken.split('.')[1] || '')).userId || ''; } catch {}
+  }
+
+  const fetchData = async () => {
+    if (!proposalId) return;
+    setLoading(true);
+    try {
+      const [propRes, commentsRes] = await Promise.all([
+        proposalsApi.getById(proposalId),
+        proposalsApi.getComments(proposalId),
+      ]);
+      setProposal(propRes.data);
+      setComments(commentsRes.data);
+    } catch {}
+    finally { setLoading(false); }
+  };
+
+  useEffect(() => { fetchData(); }, [proposalId]);
+
+  const handleAddComment = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!newComment.trim() || !proposalId) return;
+    setSubmittingComment(true);
+    try {
+      await proposalsApi.addComment(proposalId, newComment.trim());
+      setNewComment('');
+      fetchData();
+    } catch {}
+    finally { setSubmittingComment(false); }
+  };
+
+  const handleAddReply = async (commentId: string) => {
+    if (!replyContent.trim()) return;
+    setSubmittingReply(true);
+    try {
+      await proposalsApi.addReply(commentId, replyContent.trim());
+      setReplyContent('');
+      setReplyingTo(null);
+      fetchData();
+    } catch {}
+    finally { setSubmittingReply(false); }
+  };
+
+  if (loading) return <div style={styles.loading}>불러오는 중...</div>;
+
+  return (
+    <div style={styles.container}>
+      <Link to={`/groups/${proposal?.groupId}/discussions`} style={styles.backLink}>← 토론 페이지로</Link>
+
+      {/* 주제 헤더 */}
+      <div style={styles.topicSection}>
+        <div style={styles.topicTitle}>{proposal?.title || '토론 주제'}</div>
+        {proposal?.content && <div style={styles.topicContent}>{proposal.content}</div>}
+        <div style={styles.topicMeta}>
+          {proposal?.author?.nickname || ''} · {proposal?.createdAt ? timeAgo(proposal.createdAt) : ''}
+          {proposal?.status === 'opened' && <span style={{ marginLeft: 8, backgroundColor: '#c6f6d5', color: '#276749', padding: '2px 8px', borderRadius: 12, fontSize: 11 }}>개최됨</span>}
+        </div>
+      </div>
+
+      {/* 의견 목록 */}
+      <div style={styles.section}>
+        <div style={styles.sectionTitle}>의견 목록</div>
+        {comments.length === 0 ? (
+          <div style={styles.emptyState}>아직 의견이 없습니다. 첫 의견을 남겨보세요!</div>
+        ) : (
+          comments.map((comment) => (
+            <div key={comment.id} style={styles.commentCard}>
+              <div style={styles.commentAuthor}>{comment.author.nickname}</div>
+              <div style={styles.commentContent}>{comment.content}</div>
+              <div style={styles.commentMeta}>
+                {timeAgo(comment.createdAt)}
+                {' · '}
+                <button
+                  style={styles.replyToggle}
+                  onClick={() => {
+                    setReplyingTo(replyingTo === comment.id ? null : comment.id);
+                    setReplyContent('');
+                  }}
+                >
+                  {replyingTo === comment.id ? '취소' : '댓글 달기'}
+                </button>
+              </div>
+
+              {/* 답글 작성 */}
+              {replyingTo === comment.id && (
+                <div style={{ ...styles.formRow, marginLeft: 24 }}>
+                  <input
+                    type="text"
+                    style={styles.input}
+                    value={replyContent}
+                    onChange={(e) => setReplyContent(e.target.value)}
+                    placeholder="댓글을 작성해주세요"
+                    onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), handleAddReply(comment.id))}
+                  />
+                  <button
+                    style={styles.submitBtn}
+                    onClick={() => handleAddReply(comment.id)}
+                    disabled={submittingReply}
+                  >
+                    {submittingReply ? '...' : '댓글'}
+                  </button>
+                </div>
+              )}
+
+              {/* 답글 목록 */}
+              {comment.replies && comment.replies.length > 0 && (
+                <div style={styles.replySection}>
+                  {comment.replies.map((reply) => (
+                    <div key={reply.id} style={styles.replyCard}>
+                      <div style={styles.replyAuthor}>{reply.author.nickname}</div>
+                      <div style={styles.replyContent}>{reply.content}</div>
+                      <div style={styles.replyMeta}>{timeAgo(reply.createdAt)}</div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* 의견 작성 */}
+      <div style={styles.section}>
+        <div style={styles.sectionTitle}>의견 작성</div>
+        <form onSubmit={handleAddComment}>
+          <div style={styles.formRow}>
+            <input
+              type="text"
+              style={styles.input}
+              value={newComment}
+              onChange={(e) => setNewComment(e.target.value)}
+              placeholder="의견을 작성해주세요"
+            />
+            <button type="submit" style={styles.submitBtn} disabled={submittingComment}>
+              {submittingComment ? '작성 중...' : '의견 작성'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default ProposalThreadPage;

--- a/docs/feature-topic-proposal-system.md
+++ b/docs/feature-topic-proposal-system.md
@@ -1,0 +1,76 @@
+# 토론 주제 제안/개최 시스템 구현
+
+관련 이슈: #16
+브랜치: `16-feature-모임장-대시보드-관리기능`
+
+## 개요
+
+기존에 "토론 주제"와 "실제 토론"이 같은 모델(Discussion)에 저장되어 구분이 없던 문제를 해결하기 위해, 별도의 `TopicProposal` 모델을 도입하여 주제 제안과 실제 토론을 분리했습니다.
+
+## 흐름
+
+1. **참여자가 토론 페이지에서 주제를 제안** → `TopicProposal` 테이블에 `status: 'proposed'`로 저장
+2. **토론 페이지의 "토론 주제 목록"에서 제안된 주제 확인** → 클릭하면 의견/댓글 작성 가능
+3. **모임장이 대시보드 "토론 생성" 탭에서 제안된 주제를 선택** → "토론 개최" 클릭
+4. **토론 개최** → `Discussion` 테이블에 실제 토론 생성, 제안의 status가 `opened`로 변경
+5. **토론 페이지의 "열린 토론 목록"에서 개최된 토론 확인** → 클릭하면 기존 스레드 페이지로 이동
+
+## DB 스키마 변경
+
+### 새 모델: TopicProposal
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| id | UUID | PK |
+| groupId | UUID | FK → Group |
+| authorId | UUID | FK → User |
+| title | VARCHAR(200) | 주제 제목 |
+| content | TEXT | 주제 내용 (선택) |
+| memoId | UUID | 연결된 메모 (선택) |
+| status | VARCHAR(20) | proposed / opened |
+| createdAt | TIMESTAMP | 생성일 |
+
+### Comment 모델 변경
+- `discussionId`를 nullable로 변경
+- `proposalId` 필드 추가 (nullable)
+- Discussion 또는 TopicProposal 둘 중 하나에 연결
+
+### Discussion 모델 변경
+- `proposalId` 필드 추가 (개최 시 원본 제안 참조)
+
+## 변경된 파일
+
+### 백엔드
+- `server/prisma/schema.prisma` — TopicProposal 모델 추가, Comment에 proposalId 추가
+- `server/src/services/proposal.service.ts` (신규) — 제안 CRUD, 토론 개최, 의견/답글 추가
+- `server/src/routes/proposal.routes.ts` (신규) — 제안 관련 API 엔드포인트
+- `server/src/index.ts` — proposalRouter 등록
+
+### 프론트엔드
+- `client/src/api/proposals.ts` (신규) — 제안 API 클라이언트
+- `client/src/pages/ProposalThreadPage.tsx` (신규) — 제안 상세 페이지 (의견/댓글 기능)
+- `client/src/pages/DiscussionsPage.tsx` — "토론 주제 목록" + "열린 토론 목록" 분리
+- `client/src/pages/DashboardPage.tsx` — "토론 생성" 탭에서 제안 선택 → 토론 개최
+- `client/src/App.tsx` — `/proposals/:id` 라우트 추가
+
+## API 엔드포인트
+
+| 메서드 | 경로 | 설명 | 권한 |
+|--------|------|------|------|
+| GET | `/api/groups/:groupId/proposals` | 주제 제안 목록 | 로그인 |
+| POST | `/api/groups/:groupId/proposals` | 주제 제안 생성 | 참여자 |
+| GET | `/api/proposals/:id` | 제안 단건 조회 | 로그인 |
+| POST | `/api/proposals/:id/open` | 토론 개최 | 방장 |
+| DELETE | `/api/proposals/:id` | 제안 삭제 | 작성자/방장 |
+| GET | `/api/proposals/:id/comments` | 제안 의견 목록 | 로그인 |
+| POST | `/api/proposals/:id/comments` | 제안에 의견 작성 | 참여자 |
+| POST | `/api/proposal-comments/:id/replies` | 제안 의견에 답글 | 참여자 |
+
+## 토론 페이지 구조 변경
+
+### 변경 전
+- 토론 주제 목록 (Discussion 데이터, 클릭 시 스레드 이동)
+
+### 변경 후
+- **토론 주제 목록** — TopicProposal 데이터, 클릭 시 `/proposals/:id`로 이동 (의견/댓글 가능)
+- **열린 토론 목록** — Discussion 데이터 (모임장이 개최한 것만), 클릭 시 `/discussions/:id`로 이동

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "dependencies": {
         "@prisma/client": "^6.9.0",
-        "@types/multer": "^2.1.0",
         "axios": "^1.7.9",
         "bcrypt": "^5.1.1",
         "cors": "^2.8.5",
@@ -24,6 +23,7 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
         "@types/jsonwebtoken": "^9.0.9",
+        "@types/multer": "^2.1.0",
         "@types/node": "^22.10.0",
         "@types/supertest": "^7.2.0",
         "fast-check": "^3.23.2",
@@ -1044,6 +1044,7 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -1065,6 +1066,7 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1105,6 +1107,7 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -1116,6 +1119,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
       "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -1128,6 +1132,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
@@ -1159,6 +1164,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
       "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/express": "*"
@@ -1168,6 +1174,7 @@
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1177,18 +1184,21 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
       "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1198,6 +1208,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
       "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -4409,6 +4420,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@prisma/client": "^6.9.0",
-    "@types/multer": "^2.1.0",
     "axios": "^1.7.9",
     "bcrypt": "^5.1.1",
     "cors": "^2.8.5",
@@ -28,6 +27,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
     "@types/jsonwebtoken": "^9.0.9",
+    "@types/multer": "^2.1.0",
     "@types/node": "^22.10.0",
     "@types/supertest": "^7.2.0",
     "fast-check": "^3.23.2",

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -22,13 +22,14 @@ model User {
   deletedAt       DateTime? @map("deleted_at")
   createdAt       DateTime @default(now()) @map("created_at")
 
-  groupMembers GroupMember[]
-  memos        Memo[]
-  discussions  Discussion[]
-  comments     Comment[]
-  replies      Reply[]
-  ownedGroups  Group[]      @relation("GroupOwner")
-  bans         GroupBan[]
+  groupMembers   GroupMember[]
+  memos          Memo[]
+  discussions    Discussion[]
+  comments       Comment[]
+  replies        Reply[]
+  ownedGroups    Group[]          @relation("GroupOwner")
+  bans           GroupBan[]
+  proposals      TopicProposal[]
 
   @@map("users")
 }
@@ -72,6 +73,7 @@ model Group {
   announcements Announcement[]
   bans          GroupBan[]
   schedules     DiscussionSchedule[]
+  proposals     TopicProposal[]
 
   @@map("groups")
 }
@@ -114,29 +116,51 @@ model Discussion {
   id            String   @id @default(uuid())
   groupId       String   @map("group_id")
   authorId      String   @map("author_id")
+  proposalId    String?  @map("proposal_id")
   memoId        String?  @map("memo_id")
   title         String   @db.VarChar(200)
   content       String?  @db.Text
   isRecommended Boolean  @default(false) @map("is_recommended")
   createdAt     DateTime @default(now()) @map("created_at")
 
-  group    Group     @relation(fields: [groupId], references: [id])
-  author   User      @relation(fields: [authorId], references: [id])
-  memo     Memo?     @relation(fields: [memoId], references: [id])
+  group    Group          @relation(fields: [groupId], references: [id])
+  author   User           @relation(fields: [authorId], references: [id])
+  memo     Memo?          @relation(fields: [memoId], references: [id])
+  proposal TopicProposal? @relation(fields: [proposalId], references: [id])
   comments Comment[]
 
   @@map("discussions")
 }
 
+model TopicProposal {
+  id        String   @id @default(uuid())
+  groupId   String   @map("group_id")
+  authorId  String   @map("author_id")
+  title     String   @db.VarChar(200)
+  content   String?  @db.Text
+  memoId    String?  @map("memo_id")
+  status    String   @default("proposed") @db.VarChar(20)
+  createdAt DateTime @default(now()) @map("created_at")
+
+  group       Group       @relation(fields: [groupId], references: [id])
+  author      User        @relation(fields: [authorId], references: [id])
+  discussions Discussion[]
+  comments    Comment[]
+
+  @@map("topic_proposals")
+}
+
 model Comment {
   id           String   @id @default(uuid())
-  discussionId String   @map("discussion_id")
+  discussionId String?  @map("discussion_id")
+  proposalId   String?  @map("proposal_id")
   authorId     String   @map("author_id")
   content      String   @db.Text
   createdAt    DateTime @default(now()) @map("created_at")
 
-  discussion Discussion @relation(fields: [discussionId], references: [id])
-  author     User       @relation(fields: [authorId], references: [id])
+  discussion Discussion?    @relation(fields: [discussionId], references: [id])
+  proposal   TopicProposal? @relation(fields: [proposalId], references: [id])
+  author     User           @relation(fields: [authorId], references: [id])
   replies    Reply[]
 
   @@map("comments")

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -11,6 +11,7 @@ import discussionRouter from './routes/discussion.routes';
 import mypageRouter from './routes/mypage.routes';
 import dashboardRouter from './routes/dashboard.routes';
 import aiRouter from './routes/ai.routes';
+import proposalRouter from './routes/proposal.routes';
 import { globalErrorHandler } from './middleware/errorHandler';
 
 const app = express();
@@ -50,6 +51,7 @@ app.use('/api', discussionRouter);
 app.use('/api/me', mypageRouter);
 app.use('/api', dashboardRouter);
 app.use('/api', aiRouter);
+app.use('/api', proposalRouter);
 
 // 글로벌 에러 핸들러 (모든 라우터 뒤에 등록)
 app.use(globalErrorHandler);

--- a/server/src/routes/proposal.routes.ts
+++ b/server/src/routes/proposal.routes.ts
@@ -1,0 +1,135 @@
+import { Router, Response } from 'express';
+import { proposalService } from '../services/proposal.service';
+import { AppError } from '../services/auth.service';
+import { authMiddleware, AuthRequest } from '../middleware/auth.middleware';
+
+const router = Router();
+
+// GET /api/groups/:groupId/proposals - 주제 제안 목록
+router.get('/groups/:groupId/proposals', authMiddleware, async (req: AuthRequest, res: Response) => {
+  try {
+    const proposals = await proposalService.listByGroup(req.params.groupId as string);
+    res.json(proposals);
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: { code: err.code, message: err.message } });
+      return;
+    }
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: '서버 오류가 발생했습니다' } });
+  }
+});
+
+// POST /api/groups/:groupId/proposals - 주제 제안 생성
+router.post('/groups/:groupId/proposals', authMiddleware, async (req: AuthRequest, res: Response) => {
+  try {
+    const { title, content, memoId } = req.body;
+    if (!title || !title.trim()) {
+      res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: '주제 제목을 입력해주세요' } });
+      return;
+    }
+    const proposal = await proposalService.create(req.params.groupId as string, req.user!.userId, { title: title.trim(), content, memoId });
+    res.status(201).json(proposal);
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: { code: err.code, message: err.message } });
+      return;
+    }
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: '서버 오류가 발생했습니다' } });
+  }
+});
+
+// POST /api/proposals/:id/open - 토론 개최 (방장)
+router.post('/proposals/:id/open', authMiddleware, async (req: AuthRequest, res: Response) => {
+  try {
+    const discussion = await proposalService.openDiscussion(req.params.id as string, req.user!.userId);
+    res.status(201).json(discussion);
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: { code: err.code, message: err.message } });
+      return;
+    }
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: '서버 오류가 발생했습니다' } });
+  }
+});
+
+// DELETE /api/proposals/:id - 제안 삭제
+router.delete('/proposals/:id', authMiddleware, async (req: AuthRequest, res: Response) => {
+  try {
+    await proposalService.delete(req.params.id as string, req.user!.userId);
+    res.json({ message: '제안이 삭제되었습니다' });
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: { code: err.code, message: err.message } });
+      return;
+    }
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: '서버 오류가 발생했습니다' } });
+  }
+});
+
+// GET /api/proposals/:id/comments - 제안의 의견 목록
+router.get('/proposals/:id/comments', authMiddleware, async (req: AuthRequest, res: Response) => {
+  try {
+    const comments = await proposalService.getComments(req.params.id as string);
+    res.json(comments);
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: { code: err.code, message: err.message } });
+      return;
+    }
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: '서버 오류가 발생했습니다' } });
+  }
+});
+
+// POST /api/proposals/:id/comments - 제안에 의견 작성
+router.post('/proposals/:id/comments', authMiddleware, async (req: AuthRequest, res: Response) => {
+  try {
+    const { content } = req.body;
+    if (!content || !content.trim()) {
+      res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: '의견 내용을 입력해주세요' } });
+      return;
+    }
+    const comment = await proposalService.addComment(req.params.id as string, req.user!.userId, content.trim());
+    res.status(201).json(comment);
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: { code: err.code, message: err.message } });
+      return;
+    }
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: '서버 오류가 발생했습니다' } });
+  }
+});
+
+// POST /api/proposal-comments/:id/replies - 제안 의견에 답글
+router.post('/proposal-comments/:id/replies', authMiddleware, async (req: AuthRequest, res: Response) => {
+  try {
+    const { content } = req.body;
+    if (!content || !content.trim()) {
+      res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: '댓글 내용을 입력해주세요' } });
+      return;
+    }
+    const reply = await proposalService.addReply(req.params.id as string, req.user!.userId, content.trim());
+    res.status(201).json(reply);
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: { code: err.code, message: err.message } });
+      return;
+    }
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: '서버 오류가 발생했습니다' } });
+  }
+});
+
+// GET /api/proposals/:id - 제안 단건 조회
+router.get('/proposals/:id', authMiddleware, async (req: AuthRequest, res: Response) => {
+  try {
+    const proposal = await proposalService.getById(req.params.id as string);
+    res.json(proposal);
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: { code: err.code, message: err.message } });
+      return;
+    }
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: '서버 오류가 발생했습니다' } });
+  }
+});
+
+export default router;

--- a/server/src/services/dashboard.service.ts
+++ b/server/src/services/dashboard.service.ts
@@ -182,11 +182,14 @@ export const dashboardService = {
   async deleteComment(commentId: string, userId: string) {
     const comment = await prisma.comment.findUnique({
       where: { id: commentId },
-      include: { discussion: true },
+      include: { discussion: true, proposal: true },
     });
     if (!comment) throw new AppError(404, 'NOT_FOUND', '의견을 찾을 수 없습니다');
 
-    const group = await prisma.group.findUnique({ where: { id: comment.discussion.groupId } });
+    const groupId = comment.discussion?.groupId || comment.proposal?.groupId;
+    if (!groupId) throw new AppError(404, 'NOT_FOUND', '모임을 찾을 수 없습니다');
+
+    const group = await prisma.group.findUnique({ where: { id: groupId } });
     if (!group) throw new AppError(404, 'NOT_FOUND', '모임을 찾을 수 없습니다');
 
     // 작성자 본인이거나 방장만 삭제 가능
@@ -202,11 +205,14 @@ export const dashboardService = {
   async deleteReply(replyId: string, userId: string) {
     const reply = await prisma.reply.findUnique({
       where: { id: replyId },
-      include: { comment: { include: { discussion: true } } },
+      include: { comment: { include: { discussion: true, proposal: true } } },
     });
     if (!reply) throw new AppError(404, 'NOT_FOUND', '답글을 찾을 수 없습니다');
 
-    const group = await prisma.group.findUnique({ where: { id: reply.comment.discussion.groupId } });
+    const groupId = reply.comment.discussion?.groupId || reply.comment.proposal?.groupId;
+    if (!groupId) throw new AppError(404, 'NOT_FOUND', '모임을 찾을 수 없습니다');
+
+    const group = await prisma.group.findUnique({ where: { id: groupId } });
     if (!group) throw new AppError(404, 'NOT_FOUND', '모임을 찾을 수 없습니다');
 
     if (reply.authorId !== userId && group.ownerId !== userId) {

--- a/server/src/services/discussion.service.ts
+++ b/server/src/services/discussion.service.ts
@@ -140,8 +140,12 @@ export const discussionService = {
     }
 
     // Verify user is a member of the group
+    const groupId = comment.discussion?.groupId;
+    if (!groupId) {
+      throw new AppError(400, 'VALIDATION_ERROR', '해당 의견의 토론 정보를 찾을 수 없습니다');
+    }
     const member = await prisma.groupMember.findUnique({
-      where: { groupId_userId: { groupId: comment.discussion.groupId, userId } },
+      where: { groupId_userId: { groupId, userId } },
     });
     if (!member) {
       throw new AppError(403, 'FORBIDDEN', '모임 참여자만 댓글을 작성할 수 있습니다');

--- a/server/src/services/proposal.service.ts
+++ b/server/src/services/proposal.service.ts
@@ -1,0 +1,170 @@
+import { PrismaClient } from '@prisma/client';
+import { AppError } from './auth.service';
+
+const prisma = new PrismaClient();
+
+export const proposalService = {
+  // 주제 제안 생성 (참여자)
+  async create(groupId: string, userId: string, data: { title: string; content?: string; memoId?: string }) {
+    const member = await prisma.groupMember.findUnique({
+      where: { groupId_userId: { groupId, userId } },
+    });
+    if (!member) throw new AppError(403, 'FORBIDDEN', '모임 참여자만 주제를 제안할 수 있습니다');
+
+    const proposal = await prisma.topicProposal.create({
+      data: {
+        groupId,
+        authorId: userId,
+        title: data.title,
+        content: data.content ?? null,
+        memoId: data.memoId ?? null,
+        status: 'proposed',
+      },
+      include: {
+        author: { select: { id: true, nickname: true } },
+      },
+    });
+
+    return proposal;
+  },
+
+  // 주제 제안 목록 조회
+  async listByGroup(groupId: string) {
+    const proposals = await prisma.topicProposal.findMany({
+      where: { groupId },
+      orderBy: { createdAt: 'desc' },
+      include: {
+        author: { select: { id: true, nickname: true } },
+        _count: { select: { comments: true } },
+      },
+    });
+
+    return proposals.map(p => ({
+      id: p.id,
+      groupId: p.groupId,
+      authorId: p.authorId,
+      title: p.title,
+      content: p.content,
+      memoId: p.memoId,
+      status: p.status,
+      createdAt: p.createdAt,
+      author: p.author,
+      commentCount: p._count.comments,
+    }));
+  },
+
+  // 토론 개최 (모임장이 제안을 선택하여 Discussion 생성)
+  async openDiscussion(proposalId: string, userId: string) {
+    const proposal = await prisma.topicProposal.findUnique({
+      where: { id: proposalId },
+    });
+    if (!proposal) throw new AppError(404, 'NOT_FOUND', '제안을 찾을 수 없습니다');
+
+    const group = await prisma.group.findUnique({ where: { id: proposal.groupId } });
+    if (!group) throw new AppError(404, 'NOT_FOUND', '모임을 찾을 수 없습니다');
+    if (group.ownerId !== userId) throw new AppError(403, 'FORBIDDEN', '방장만 토론을 개최할 수 있습니다');
+
+    if (proposal.status === 'opened') {
+      throw new AppError(409, 'ALREADY_OPENED', '이미 개최된 주제입니다');
+    }
+
+    // Discussion 생성 + proposal status 업데이트
+    const discussion = await prisma.discussion.create({
+      data: {
+        groupId: proposal.groupId,
+        authorId: userId,
+        proposalId: proposal.id,
+        memoId: proposal.memoId,
+        title: proposal.title,
+        content: proposal.content,
+        isRecommended: false,
+      },
+      include: {
+        author: { select: { id: true, nickname: true } },
+      },
+    });
+
+    await prisma.topicProposal.update({
+      where: { id: proposalId },
+      data: { status: 'opened' },
+    });
+
+    return discussion;
+  },
+
+  // 제안 삭제 (작성자 또는 방장)
+  async delete(proposalId: string, userId: string) {
+    const proposal = await prisma.topicProposal.findUnique({ where: { id: proposalId } });
+    if (!proposal) throw new AppError(404, 'NOT_FOUND', '제안을 찾을 수 없습니다');
+
+    const group = await prisma.group.findUnique({ where: { id: proposal.groupId } });
+    if (proposal.authorId !== userId && group?.ownerId !== userId) {
+      throw new AppError(403, 'FORBIDDEN', '본인의 제안이거나 방장만 삭제할 수 있습니다');
+    }
+
+    await prisma.topicProposal.delete({ where: { id: proposalId } });
+  },
+
+  // 제안에 의견 추가
+  async addComment(proposalId: string, userId: string, content: string) {
+    const proposal = await prisma.topicProposal.findUnique({ where: { id: proposalId } });
+    if (!proposal) throw new AppError(404, 'NOT_FOUND', '제안을 찾을 수 없습니다');
+
+    const member = await prisma.groupMember.findUnique({
+      where: { groupId_userId: { groupId: proposal.groupId, userId } },
+    });
+    if (!member) throw new AppError(403, 'FORBIDDEN', '모임 참여자만 의견을 작성할 수 있습니다');
+
+    return prisma.comment.create({
+      data: { proposalId, authorId: userId, content },
+      include: { author: { select: { id: true, nickname: true } } },
+    });
+  },
+
+  // 제안의 의견 목록 조회
+  async getComments(proposalId: string) {
+    const proposal = await prisma.topicProposal.findUnique({ where: { id: proposalId } });
+    if (!proposal) throw new AppError(404, 'NOT_FOUND', '제안을 찾을 수 없습니다');
+
+    return prisma.comment.findMany({
+      where: { proposalId },
+      orderBy: { createdAt: 'asc' },
+      include: {
+        author: { select: { id: true, nickname: true } },
+        replies: {
+          orderBy: { createdAt: 'asc' },
+          include: { author: { select: { id: true, nickname: true } } },
+        },
+      },
+    });
+  },
+
+  // 제안 의견에 답글 추가
+  async addReply(commentId: string, userId: string, content: string) {
+    const comment = await prisma.comment.findUnique({
+      where: { id: commentId },
+      include: { proposal: true },
+    });
+    if (!comment || !comment.proposal) throw new AppError(404, 'NOT_FOUND', '의견을 찾을 수 없습니다');
+
+    const member = await prisma.groupMember.findUnique({
+      where: { groupId_userId: { groupId: comment.proposal.groupId, userId } },
+    });
+    if (!member) throw new AppError(403, 'FORBIDDEN', '모임 참여자만 댓글을 작성할 수 있습니다');
+
+    return prisma.reply.create({
+      data: { commentId, authorId: userId, content },
+      include: { author: { select: { id: true, nickname: true } } },
+    });
+  },
+
+  // 제안 단건 조회
+  async getById(proposalId: string) {
+    const proposal = await prisma.topicProposal.findUnique({
+      where: { id: proposalId },
+      include: { author: { select: { id: true, nickname: true } } },
+    });
+    if (!proposal) throw new AppError(404, 'NOT_FOUND', '제안을 찾을 수 없습니다');
+    return proposal;
+  },
+};


### PR DESCRIPTION

## 📝 PR 요약
<!-- 이 PR의 목적과 주요 변경 사항을 간략하게 설명해 주세요. -->
토론 주제 제안과 실제 토론을 별도 모델로 분리하여, 참여자가 주제를 제안하고 모임장이 선별하여 토론을 개최하는 흐름을 구현합니다.
- TopicProposal 모델 추가 (주제 제안 전용)
- 제안에 의견/댓글 기능 (Comment/Reply를 TopicProposal에 직접 연결)
- 모임장 대시보드 "토론 생성" 탭에서 제안 선택 → 토론 개최
- 토론 페이지를 "토론 주제 목록"(제안)과 "열린 토론 목록"(개최된 토론)으로 분리
- ProposalThreadPage 추가 (제안 상세 - 의견 작성/목록/댓글)
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 적어주세요. 이슈를 자동으로 닫으려면 'Resolves #이슈번호' 형태로 작성하세요. -->
- Resolves: #45

## 🏷️ PR 분류
<!-- 해당되는 항목의 [ ] 안에 x를 입력하여 [x]로 만들어 주세요. -->
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ✨ 새로운 기능 추가 (New Feature)
- [ ] 🛠️ 코드 리팩토링 (Refactoring)
- [ ] 📚 문서 수정 (Documentation)
- [ ] ⚙️ 설정/빌드 환경 수정 (Configuration/Build)
- [ ] 🧹 단순 수정 (기능에 영향을 주지 않는 오타 수정, 포맷팅 등)

## 🧪 테스트 방법
<!-- 변경 사항이 정상적으로 동작하는지 확인하기 위해 진행한 테스트 방법과 결과를 설명해 주세요. -->
1. 모임에 참여한 계정으로 토론 페이지 접속
2. "토론 주제 만들기" 버튼으로 주제 제안
3. "토론 주제 목록"에서 제안된 주제 확인 → 클릭하여 의견/댓글 작성
4. 모임장 계정으로 대시보드 → "토론 생성" 탭에서 제안된 주제 확인
5. "토론 개최" 버튼 클릭 → 토론 생성 확인
6. 토론 페이지의 "열린 토론 목록"에서 개최된 토론 확인 → 클릭하여 스레드 이동
## 📸 스크린샷 또는 GIF (선택 사항)
<!-- UI 변경 사항이나 시각적으로 확인할 수 있는 결과물이 있다면 첨부해 주세요. -->
