### PR TITLE
feat: 책수다 페이지 리뉴얼 - 스레드 종료일/상태 관리, 대표 수다 고정, 책수다 관리 탭 추가

### DIFF
--- a/client/src/api/discussions.ts
+++ b/client/src/api/discussions.ts
@@ -40,4 +40,13 @@ export const discussionsApi = {
 
   getRecommendations: (groupId: string) =>
     apiClient.get<RecommendedTopic[]>(`/groups/${groupId}/discussions/recommendations`),
+
+  updateEndDate: (discussionId: string, endDate: string) =>
+    apiClient.patch(`/discussions/${discussionId}/end-date`, { endDate }),
+
+  pinThread: (discussionId: string) =>
+    apiClient.post(`/discussions/${discussionId}/pin`),
+
+  unpinThread: (discussionId: string) =>
+    apiClient.delete(`/discussions/${discussionId}/pin`),
 };

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -4,14 +4,14 @@ import { dashboardApi, type Announcement, type DiscussionSchedule } from '../api
 import { groupsApi } from '../api/groups';
 import { discussionsApi } from '../api/discussions';
 import { useAuthStore } from '../stores/authStore';
-import type { GroupDetail, RecommendedTopic } from '../types';
+import type { GroupDetail, Discussion } from '../types';
 
 const tabs = [
   { id: 'calendar', label: '📅 토론 일정' },
   { id: 'invite', label: '🔗 초대 링크' },
   { id: 'announcements', label: '📢 공지사항' },
   { id: 'members', label: '👥 멤버 관리' },
-  { id: 'topics', label: '💡 추천 주제' },
+  { id: 'threads', label: '📚 책수다 관리' },
 ] as const;
 
 type TabId = typeof tabs[number]['id'];
@@ -36,7 +36,6 @@ const styles: Record<string, React.CSSProperties> = {
   inviteBox: { backgroundColor: '#f7fafc', padding: '12px 16px', borderRadius: 6, display: 'flex', alignItems: 'center', gap: 12 },
   calGrid: { display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 2, textAlign: 'center' as const },
   calCell: { padding: '8px 4px', fontSize: 12, borderRadius: 4, minHeight: 36, display: 'flex', alignItems: 'center', justifyContent: 'center' },
-  recCard: { backgroundColor: '#f0fff4', padding: '12px 16px', borderRadius: 6, marginBottom: 8 },
 };
 
 function DashboardPage() {
@@ -50,7 +49,9 @@ function DashboardPage() {
   const [inviteExpiresAt, setInviteExpiresAt] = useState<string | null>(null);
   const [announcements, setAnnouncements] = useState<Announcement[]>([]);
   const [schedules, setSchedules] = useState<DiscussionSchedule[]>([]);
-  const [recommendations, setRecommendations] = useState<RecommendedTopic[]>([]);
+  const [threads, setThreads] = useState<Discussion[]>([]);
+  const [editingEndDateId, setEditingEndDateId] = useState<string | null>(null);
+  const [editingEndDateValue, setEditingEndDateValue] = useState('');
   const [newAnnTitle, setNewAnnTitle] = useState('');
   const [newAnnContent, setNewAnnContent] = useState('');
   const [newSchedTitle, setNewSchedTitle] = useState('');
@@ -67,19 +68,19 @@ function DashboardPage() {
   const fetchAll = async () => {
     if (!groupId) return;
     try {
-      const [gRes, invRes, annRes, recRes, schedRes] = await Promise.all([
+      const [gRes, invRes, annRes, schedRes, threadsRes] = await Promise.all([
         groupsApi.getDetail(groupId),
         dashboardApi.getInviteCode(groupId).catch(() => ({ data: { inviteCode: null, expiresAt: null } })),
         dashboardApi.listAnnouncements(groupId).catch(() => ({ data: [] })),
-        discussionsApi.getRecommendations(groupId).catch(() => ({ data: [] })),
         dashboardApi.listSchedules(groupId).catch(() => ({ data: [] })),
+        discussionsApi.listByGroup(groupId).catch(() => ({ data: [] })),
       ]);
       setGroup(gRes.data);
       setInviteCode(invRes.data.inviteCode);
       setInviteExpiresAt(invRes.data.expiresAt || null);
       setAnnouncements(annRes.data);
-      setRecommendations(recRes.data);
       setSchedules(schedRes.data);
+      setThreads(threadsRes.data);
     } catch {}
   };
 
@@ -117,12 +118,6 @@ function DashboardPage() {
     await dashboardApi.deleteAnnouncement(groupId, annId); fetchAll();
   };
 
-  const handleSelectRecommendation = async (rec: RecommendedTopic) => {
-    if (!groupId) return;
-    await discussionsApi.create(groupId, { title: rec.title, content: rec.content });
-    alert('토론 스레드가 생성되었습니다'); fetchAll();
-  };
-
   const handleCreateSchedule = async () => {
     if (!groupId || !newSchedTitle.trim() || !newSchedStart || !newSchedEnd) return;
     await dashboardApi.createSchedule(groupId, { title: newSchedTitle.trim(), startDate: newSchedStart, endDate: newSchedEnd });
@@ -132,6 +127,42 @@ function DashboardPage() {
   const handleDeleteSchedule = async (scheduleId: string) => {
     if (!groupId || !confirm('이 일정을 삭제하시겠습니까?')) return;
     await dashboardApi.deleteSchedule(groupId, scheduleId); fetchAll();
+  };
+
+  const handleUpdateEndDate = async (discussionId: string) => {
+    setEditingEndDateId(discussionId);
+    const thread = threads.find((t: any) => t.id === discussionId);
+    setEditingEndDateValue(thread?.endDate ? new Date(thread.endDate).toISOString().slice(0, 10) : '');
+  };
+
+  const handleSaveEndDate = async () => {
+    if (!editingEndDateId || !editingEndDateValue) return;
+    try {
+      await discussionsApi.updateEndDate(editingEndDateId, editingEndDateValue);
+      setEditingEndDateId(null);
+      setEditingEndDateValue('');
+      fetchAll();
+    } catch (err: any) {
+      alert(err.response?.data?.error?.message || '종료일 수정에 실패했습니다');
+    }
+  };
+
+  const handlePinThread = async (discussionId: string) => {
+    try {
+      await discussionsApi.pinThread(discussionId);
+      fetchAll();
+    } catch (err: any) {
+      alert(err.response?.data?.error?.message || '대표 설정에 실패했습니다');
+    }
+  };
+
+  const handleUnpinThread = async (discussionId: string) => {
+    try {
+      await discussionsApi.unpinThread(discussionId);
+      fetchAll();
+    } catch (err: any) {
+      alert(err.response?.data?.error?.message || '대표 해제에 실패했습니다');
+    }
   };
 
   // Calendar helpers
@@ -271,17 +302,43 @@ function DashboardPage() {
           </div>
         );
 
-      case 'topics':
+      case 'threads':
         return (
           <div style={styles.section}>
-            <div style={styles.sectionTitle}>💡 AI 추천 토론 주제</div>
-            {recommendations.length === 0 ? (
-              <div style={{ color: '#a0aec0', fontSize: 13 }}>공개 메모가 2개 이상이면 추천 주제가 생성됩니다</div>
-            ) : recommendations.map((rec, i) => (
-              <div key={i} style={styles.recCard}>
-                <div style={{ fontWeight: 600, fontSize: 14, marginBottom: 4 }}>{rec.title}</div>
-                <div style={{ fontSize: 13, color: '#4a5568', marginBottom: 8 }}>{rec.content}</div>
-                <button style={{ ...styles.btn, ...styles.btnPrimary, padding: '6px 14px', fontSize: 12 }} onClick={() => handleSelectRecommendation(rec)}>이 주제로 토론 열기</button>
+            <div style={styles.sectionTitle}>📚 책수다 관리</div>
+            <div style={{ fontSize: 13, color: '#718096', marginBottom: 16 }}>스레드 종료일 수정, 대표 수다 설정/해제를 관리합니다.</div>
+
+            {threads.length === 0 ? (
+              <div style={{ color: '#a0aec0', fontSize: 13 }}>아직 생성된 수다가 없습니다</div>
+            ) : threads.map((d: any) => (
+              <div key={d.id} style={{ padding: '12px 0', borderBottom: '1px solid #f0f0f0' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <div style={{ flex: 1 }}>
+                    <div style={{ fontSize: 14, fontWeight: 500, color: '#2d3748' }}>
+                      {d.title}
+                      {d.isPinned && <span style={{ fontSize: 11, backgroundColor: '#ebf8ff', color: '#3182ce', padding: '2px 6px', borderRadius: 10, marginLeft: 6 }}>대표</span>}
+                      {d.status === 'closed' && <span style={{ fontSize: 11, backgroundColor: '#fed7d7', color: '#c53030', padding: '2px 6px', borderRadius: 10, marginLeft: 6 }}>종료</span>}
+                    </div>
+                    <div style={{ fontSize: 12, color: '#a0aec0', marginTop: 2 }}>
+                      종료일: {d.endDate ? new Date(d.endDate).toLocaleDateString() : '없음'}
+                    </div>
+                  </div>
+                  <div style={{ display: 'flex', gap: 4 }}>
+                    <button style={{ ...styles.btn, ...styles.btnSecondary, padding: '4px 8px', fontSize: 11 }} onClick={() => handleUpdateEndDate(d.id)}>종료일 수정</button>
+                    {d.isPinned ? (
+                      <button style={{ ...styles.btn, ...styles.btnSecondary, padding: '4px 8px', fontSize: 11 }} onClick={() => handleUnpinThread(d.id)}>대표 해제</button>
+                    ) : (
+                      <button style={{ ...styles.btn, ...styles.btnPrimary, padding: '4px 8px', fontSize: 11 }} onClick={() => handlePinThread(d.id)}>대표 설정</button>
+                    )}
+                  </div>
+                </div>
+                {editingEndDateId === d.id && (
+                  <div style={{ marginTop: 8, display: 'flex', gap: 8, alignItems: 'center' }}>
+                    <input type="date" style={{ ...styles.input, marginBottom: 0, flex: 1 }} value={editingEndDateValue} onChange={e => setEditingEndDateValue(e.target.value)} />
+                    <button style={{ ...styles.btn, ...styles.btnPrimary, padding: '6px 12px', fontSize: 12 }} onClick={handleSaveEndDate}>저장</button>
+                    <button style={{ ...styles.btn, ...styles.btnSecondary, padding: '6px 12px', fontSize: 12 }} onClick={() => setEditingEndDateId(null)}>취소</button>
+                  </div>
+                )}
               </div>
             ))}
           </div>

--- a/client/src/pages/DiscussionThreadPage.tsx
+++ b/client/src/pages/DiscussionThreadPage.tsx
@@ -426,27 +426,33 @@ function DiscussionThreadPage() {
       </div>
 
       {/* Add Comment */}
-      <div style={styles.section}>
-        <div style={styles.sectionTitle}>의견 작성</div>
-        <form onSubmit={handleAddComment}>
-          <textarea
-            style={styles.textarea}
-            rows={3}
-            value={newComment}
-            onChange={(e) => setNewComment(e.target.value)}
-            placeholder="의견을 작성해주세요"
-          />
-          <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 8 }}>
-            <button
-              type="submit"
-              style={styles.submitBtn}
-              disabled={submittingComment}
-            >
-              {submittingComment ? '작성 중...' : '의견 작성'}
-            </button>
-          </div>
-        </form>
-      </div>
+      {(topic as any)?.status === 'closed' ? (
+        <div style={{ ...styles.section, backgroundColor: '#fff5f5', textAlign: 'center' as const }}>
+          <div style={{ color: '#c53030', fontSize: 14, fontWeight: 500 }}>🔴 이 스레드는 종료되었습니다. 의견 작성이 불가능합니다.</div>
+        </div>
+      ) : (
+        <div style={styles.section}>
+          <div style={styles.sectionTitle}>의견 작성</div>
+          <form onSubmit={handleAddComment}>
+            <textarea
+              style={styles.textarea}
+              rows={3}
+              value={newComment}
+              onChange={(e) => setNewComment(e.target.value)}
+              placeholder="의견을 작성해주세요"
+            />
+            <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 8 }}>
+              <button
+                type="submit"
+                style={styles.submitBtn}
+                disabled={submittingComment}
+              >
+                {submittingComment ? '작성 중...' : '의견 작성'}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
 
     </div>
   );

--- a/client/src/pages/DiscussionsPage.tsx
+++ b/client/src/pages/DiscussionsPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, type FormEvent } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { discussionsApi } from '../api/discussions';
+import { groupsApi } from '../api/groups';
 import { memosApi } from '../api/memos';
 import { aiApi, type AiTopic } from '../api/ai';
 import { useAuthStore } from '../stores/authStore';
@@ -241,6 +242,7 @@ function DiscussionsPage() {
   const accessToken = useAuthStore((s) => s.accessToken);
 
   const [discussions, setDiscussions] = useState<Discussion[]>([]);
+  const [isOwner, setIsOwner] = useState(false);
   const [recommendations, setRecommendations] = useState<RecommendedTopic[]>([]);
   const [aiTopics, setAiTopics] = useState<AiTopic[]>([]);
   const [aiLoading, setAiLoading] = useState(false);
@@ -253,6 +255,7 @@ function DiscussionsPage() {
   const [formTitle, setFormTitle] = useState('');
   const [formContent, setFormContent] = useState('');
   const [formMemoId, setFormMemoId] = useState('');
+  const [formEndDate, setFormEndDate] = useState('');
   const [formErrors, setFormErrors] = useState<Record<string, string>>({});
   const [serverError, setServerError] = useState('');
   const [submitting, setSubmitting] = useState(false);
@@ -280,6 +283,14 @@ function DiscussionsPage() {
       setDiscussions(discRes.data);
       setRecommendations(recRes.data);
       setMyMemos(memoRes.data.myMemos || []);
+
+      // 방장 여부 확인
+      if (currentUserId) {
+        const groupRes = await groupsApi.getDetail(groupId!).catch(() => ({ data: null }));
+        if (groupRes.data) {
+          setIsOwner(groupRes.data.ownerId === currentUserId);
+        }
+      }
     } catch {
       setDiscussions([]);
     } finally {
@@ -306,7 +317,8 @@ function DiscussionsPage() {
     e.preventDefault();
     setServerError('');
     const errs: Record<string, string> = {};
-    if (!formTitle.trim()) errs.title = '토론 주제를 입력해주세요';
+    if (!formTitle.trim()) errs.title = '주제를 입력해주세요';
+    if (!formEndDate) errs.endDate = '종료일을 입력해주세요';
     setFormErrors(errs);
     if (Object.keys(errs).length > 0) return;
     if (!groupId) return;
@@ -317,10 +329,12 @@ function DiscussionsPage() {
         title: formTitle.trim(),
         content: formContent.trim() || undefined,
         memoId: formMemoId || undefined,
+        endDate: formEndDate || undefined,
       });
       setFormTitle('');
       setFormContent('');
       setFormMemoId('');
+      setFormEndDate('');
       setShowCreateModal(false);
       fetchData();
     } catch (err) {
@@ -378,9 +392,9 @@ function DiscussionsPage() {
   return (
     <div style={styles.container}>
       <Link to={`/groups/${groupId}`} style={styles.backLink}>← 모임으로</Link>
-      <h1 style={styles.title}>💬 토론</h1>
+      <h1 style={styles.title}>📚 책수다</h1>
 
-      {/* 헤더: 토론 주제 만들기 버튼 */}
+      {/* 헤더: 책수다 만들기 버튼 */}
       <div style={styles.headerRow}>
         {/* Filter */}
         <div style={styles.filterRow}>
@@ -398,19 +412,15 @@ function DiscussionsPage() {
           </button>
         </div>
         <button style={styles.createBtn} onClick={() => setShowCreateModal(true)}>
-          + 토론 주제 만들기
+          + 책수다 만들기
         </button>
       </div>
 
-      {/* Discussion List */}
-      <div style={styles.section}>
-        <div style={styles.sectionTitle}>토론 주제 목록</div>
-        {loading ? (
-          <div style={styles.emptyState}>불러오는 중...</div>
-        ) : discussions.length === 0 ? (
-          <div style={styles.emptyState}>토론 주제가 없습니다</div>
-        ) : (
-          discussions.map((d) => (
+      {/* 📌 대표 수다 (고정) */}
+      {discussions.filter((d: any) => d.isPinned).length > 0 && (
+        <div style={{ ...styles.section, borderLeft: '4px solid #3182ce' }}>
+          <div style={styles.sectionTitle}>📌 대표 수다</div>
+          {discussions.filter((d: any) => d.isPinned).map((d) => (
             <div
               key={d.id}
               style={styles.discussionItem}
@@ -421,23 +431,74 @@ function DiscussionsPage() {
             >
               <div style={styles.discussionTitle}>
                 {d.title}
-                {d.isRecommended && <span style={styles.recommendedBadge}>추천</span>}
+                {(d as any).status === 'closed' && <span style={{ fontSize: 11, backgroundColor: '#fed7d7', color: '#c53030', padding: '2px 8px', borderRadius: 12, marginLeft: 8 }}>종료</span>}
+              </div>
+              <div style={styles.discussionMeta}>
+                {d.authorNickname} · {(d as any).endDate && `~${new Date((d as any).endDate).toLocaleDateString()}`}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* 진행중인 수다 */}
+      <div style={styles.section}>
+        <div style={styles.sectionTitle}>🟢 진행중인 수다</div>
+        {discussions.filter((d: any) => d.status !== 'closed').length === 0 ? (
+          <div style={styles.emptyState}>진행중인 수다가 없습니다</div>
+        ) : (
+          discussions.filter((d: any) => d.status !== 'closed').map((d) => (
+            <div
+              key={d.id}
+              style={styles.discussionItem}
+              onClick={() => navigate(`/discussions/${d.id}`)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => e.key === 'Enter' && navigate(`/discussions/${d.id}`)}
+            >
+              <div style={styles.discussionTitle}>
+                {d.title}
+                {(d as any).endDate && <span style={{ fontSize: 11, color: '#718096', marginLeft: 8 }}>~{new Date((d as any).endDate).toLocaleDateString()}</span>}
               </div>
               <div style={styles.discussionMeta}>
                 {d.authorNickname} · {new Date(d.createdAt).toLocaleDateString()}
-                {d.memoId && ' · 📝 메모 연결됨'}
               </div>
             </div>
           ))
         )}
       </div>
 
-      {/* 토론 주제 만들기 모달 */}
+      {/* 종료된 수다 */}
+      {discussions.filter((d: any) => d.status === 'closed').length > 0 && (
+        <div style={styles.section}>
+          <div style={styles.sectionTitle}>🔴 종료된 수다</div>
+          {discussions.filter((d: any) => d.status === 'closed').map((d) => (
+            <div
+              key={d.id}
+              style={{ ...styles.discussionItem, opacity: 0.6 }}
+              onClick={() => navigate(`/discussions/${d.id}`)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => e.key === 'Enter' && navigate(`/discussions/${d.id}`)}
+            >
+              <div style={styles.discussionTitle}>
+                {d.title}
+                <span style={{ fontSize: 11, backgroundColor: '#fed7d7', color: '#c53030', padding: '2px 8px', borderRadius: 12, marginLeft: 8 }}>종료</span>
+              </div>
+              <div style={styles.discussionMeta}>
+                {d.authorNickname} · {new Date(d.createdAt).toLocaleDateString()}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* 책수다 만들기 모달 */}
       {showCreateModal && (
         <div style={styles.overlay} onClick={handleOverlayClick}>
           <div style={styles.modal} onClick={(e) => e.stopPropagation()}>
             <div style={styles.modalHeader}>
-              <div style={styles.modalTitle}>💬 토론 주제 만들기</div>
+              <div style={styles.modalTitle}>💬 책수다 만들기</div>
               <button style={styles.closeBtn} onClick={() => setShowCreateModal(false)} aria-label="닫기">×</button>
             </div>
 
@@ -454,7 +515,7 @@ function DiscussionsPage() {
                     style={{ ...styles.input, ...(formErrors.title ? styles.inputError : {}) }}
                     value={formTitle}
                     onChange={(e) => setFormTitle(e.target.value)}
-                    placeholder="토론 주제를 입력해주세요"
+                    placeholder="주제를 입력해주세요"
                   />
                   {formErrors.title && <div style={styles.errorText}>{formErrors.title}</div>}
                 </div>
@@ -465,7 +526,7 @@ function DiscussionsPage() {
                     style={styles.textarea}
                     value={formContent}
                     onChange={(e) => setFormContent(e.target.value)}
-                    placeholder="토론 주제에 대한 설명 (선택)"
+                    placeholder="주제에 대한 설명 (선택)"
                   />
                 </div>
 
@@ -485,12 +546,23 @@ function DiscussionsPage() {
                   </select>
                 </div>
 
+                <div style={styles.field}>
+                  <label style={styles.label}>종료일 *</label>
+                  <input
+                    type="date"
+                    style={{ ...styles.input, ...(formErrors.endDate ? styles.inputError : {}) }}
+                    value={formEndDate}
+                    onChange={(e) => setFormEndDate(e.target.value)}
+                  />
+                  {formErrors.endDate && <div style={styles.errorText}>{formErrors.endDate}</div>}
+                </div>
+
                 <button
                   type="submit"
                   style={{ ...styles.button, ...(submitting ? styles.buttonDisabled : {}) }}
                   disabled={submitting}
                 >
-                  {submitting ? '생성 중...' : '토론 주제 만들기'}
+                  {submitting ? '생성 중...' : '책수다 만들기'}
                 </button>
               </form>
             </div>

--- a/client/src/pages/GroupDetailPage.tsx
+++ b/client/src/pages/GroupDetailPage.tsx
@@ -449,7 +449,7 @@ function GroupDetailPage() {
       {isMember && (
         <div style={styles.linkRow}>
           <Link to={`/groups/${id}/memos`} style={styles.actionLink}>📝 메모</Link>
-          <Link to={`/groups/${id}/discussions`} style={styles.actionLink}>💬 토론 페이지</Link>
+          <Link to={`/groups/${id}/discussions`} style={styles.actionLink}>📚 책수다</Link>
           {isOwner && (
             <Link to={`/groups/${id}/dashboard`} style={{ ...styles.actionLink, backgroundColor: '#fefcbf', color: '#975a16' }}>🛠️ 대시보드</Link>
           )}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -132,6 +132,7 @@ export interface CreateDiscussionRequest {
   title: string;
   content?: string;
   memoId?: string;
+  endDate?: string;
 }
 
 export interface Comment {

--- a/docs/feature-thread-renewal.md
+++ b/docs/feature-thread-renewal.md
@@ -1,0 +1,73 @@
+# 책수다(토론) 페이지 리뉴얼
+
+브랜치: `feature-thread-renewal`
+
+## 개요
+
+기존 "토론" 페이지를 "책수다"로 리브랜딩하고, 스레드 종료일/상태 관리 및 대표 수다 고정 기능을 추가했습니다.
+
+## 변경 내용
+
+### 1. 이름 변경
+- "토론" → "📚 책수다"
+- "토론 페이지" → "📚 책수다" (모임 상세 페이지 링크)
+- "토론 주제 만들기" → "책수다 만들기"
+- "진행중 스레드" → "진행중인 수다"
+- "종료된 스레드" → "종료된 수다"
+
+### 2. 스레드 종료일 및 상태 관리
+- Discussion 모델에 `status`(active/closed), `endDate` 필드 추가
+- 책수다 만들기 시 종료일 필수 입력 (date picker)
+- 종료일이 지난 스레드는 목록 조회 시 자동으로 `closed` 처리
+- 종료된 스레드에는 의견/댓글 작성 불가 (403 에러)
+- 스레드 상세 페이지에서 종료 상태 시 "종료되었습니다" 메시지 표시
+
+### 3. 대표 수다 (고정)
+- Discussion 모델에 `isPinned` 필드 추가
+- 모임장이 대시보드에서 최대 3개까지 대표 수다 설정/해제
+- 책수다 페이지 상단에 "📌 대표 수다" 섹션으로 고정 표시
+
+### 4. 모임장 대시보드 — 책수다 관리 탭
+- 모든 스레드 목록 표시 (대표/종료 뱃지)
+- 종료일 수정: 인라인 date picker로 변경 → 미래 날짜 설정 시 자동으로 진행중 복원
+- 대표 설정/해제 버튼
+- 기존 "토론 생성" 탭 삭제
+
+### 5. 책수다 페이지 구조
+- 📌 대표 수다 (고정, 상단)
+- 🟢 진행중인 수다
+- 🔴 종료된 수다
+
+## DB 스키마 변경
+
+Discussion 모델:
+```
+status    String    @default("active") @db.VarChar(20)
+endDate   DateTime? @db.Date
+isPinned  Boolean   @default(false)
+```
+
+## API 엔드포인트
+
+| 메서드 | 경로 | 설명 | 권한 |
+|--------|------|------|------|
+| GET | `/api/groups/:groupId/discussions?status=active` | 상태별 필터 조회 | 로그인 |
+| PATCH | `/api/discussions/:id/end-date` | 종료일 수정 | 방장 |
+| POST | `/api/discussions/:id/pin` | 대표 수다 설정 | 방장 |
+| DELETE | `/api/discussions/:id/pin` | 대표 수다 해제 | 방장 |
+
+## 변경된 파일
+
+### 백엔드
+- `server/prisma/schema.prisma` — Discussion에 status, endDate, isPinned 추가
+- `server/src/services/discussion.service.ts` — 자동 종료, 종료 차단, 종료일 수정, 핀 설정/해제
+- `server/src/routes/discussion.routes.ts` — 새 엔드포인트 추가, status 필터 지원
+- `server/src/validators/index.ts` — CreateDiscussionSchema에 endDate 추가
+
+### 프론트엔드
+- `client/src/pages/DiscussionsPage.tsx` — "책수다" 리브랜딩, 대표/진행중/종료 분류, 종료일 필수
+- `client/src/pages/DiscussionThreadPage.tsx` — 종료 상태 시 의견 작성 폼 숨김
+- `client/src/pages/GroupDetailPage.tsx` — "토론 페이지" → "📚 책수다"
+- `client/src/pages/DashboardPage.tsx` — "책수다 관리" 탭 추가, "토론 생성" 탭 삭제
+- `client/src/api/discussions.ts` — updateEndDate, pinThread, unpinThread 추가
+- `client/src/types/index.ts` — CreateDiscussionRequest에 endDate 추가

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -111,14 +111,17 @@ model Memo {
 }
 
 model Discussion {
-  id            String   @id @default(uuid())
-  groupId       String   @map("group_id")
-  authorId      String   @map("author_id")
-  memoId        String?  @map("memo_id")
-  title         String   @db.VarChar(200)
-  content       String?  @db.Text
-  isRecommended Boolean  @default(false) @map("is_recommended")
-  createdAt     DateTime @default(now()) @map("created_at")
+  id            String    @id @default(uuid())
+  groupId       String    @map("group_id")
+  authorId      String    @map("author_id")
+  memoId        String?   @map("memo_id")
+  title         String    @db.VarChar(200)
+  content       String?   @db.Text
+  isRecommended Boolean   @default(false) @map("is_recommended")
+  isPinned      Boolean   @default(false) @map("is_pinned")
+  status        String    @default("active") @map("status") @db.VarChar(20)
+  endDate       DateTime? @map("end_date") @db.Date
+  createdAt     DateTime  @default(now()) @map("created_at")
 
   group    Group     @relation(fields: [groupId], references: [id])
   author   User      @relation(fields: [authorId], references: [id])

--- a/server/src/routes/discussion.routes.ts
+++ b/server/src/routes/discussion.routes.ts
@@ -10,9 +10,10 @@ const router = Router();
 router.get('/groups/:groupId/discussions', authMiddleware, async (req: AuthRequest, res: Response) => {
   try {
     const authorId = typeof req.query.authorId === 'string' ? req.query.authorId : undefined;
+    const status = typeof req.query.status === 'string' ? req.query.status : undefined;
     const discussions = await discussionService.listTopics(
       req.params.groupId as string,
-      authorId ? { authorId } : undefined,
+      { ...(authorId && { authorId }), ...(status && { status }) },
     );
     res.json(discussions);
   } catch (err) {
@@ -160,6 +161,53 @@ router.post('/comments/:id/replies', authMiddleware, async (req: AuthRequest, re
     res.status(500).json({
       error: { code: 'INTERNAL_ERROR', message: '서버 오류가 발생했습니다' },
     });
+  }
+});
+
+// PATCH /api/discussions/:id/end-date - 종료일 수정 (방장)
+router.patch('/discussions/:id/end-date', authMiddleware, async (req: AuthRequest, res: Response) => {
+  try {
+    const { endDate } = req.body;
+    if (!endDate) {
+      res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: '종료일을 입력해주세요' } });
+      return;
+    }
+    const result = await discussionService.updateEndDate(req.params.id as string, req.user!.userId, endDate);
+    res.json(result);
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: { code: err.code, message: err.message } });
+      return;
+    }
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: '서버 오류가 발생했습니다' } });
+  }
+});
+
+// POST /api/discussions/:id/pin - 대표 스레드 설정 (방장)
+router.post('/discussions/:id/pin', authMiddleware, async (req: AuthRequest, res: Response) => {
+  try {
+    const result = await discussionService.pinThread(req.params.id as string, req.user!.userId);
+    res.json(result);
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: { code: err.code, message: err.message } });
+      return;
+    }
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: '서버 오류가 발생했습니다' } });
+  }
+});
+
+// DELETE /api/discussions/:id/pin - 대표 스레드 해제 (방장)
+router.delete('/discussions/:id/pin', authMiddleware, async (req: AuthRequest, res: Response) => {
+  try {
+    const result = await discussionService.unpinThread(req.params.id as string, req.user!.userId);
+    res.json(result);
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: { code: err.code, message: err.message } });
+      return;
+    }
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: '서버 오류가 발생했습니다' } });
   }
 });
 

--- a/server/src/services/discussion.service.ts
+++ b/server/src/services/discussion.service.ts
@@ -40,6 +40,8 @@ export const discussionService = {
         title: data.title,
         content: data.content ?? null,
         isRecommended: false,
+        status: 'active',
+        endDate: data.endDate ? new Date(data.endDate) : null,
       },
       include: {
         author: { select: { id: true, nickname: true } },
@@ -67,10 +69,23 @@ export const discussionService = {
     };
   },
 
-  async listTopics(groupId: string, filter?: { authorId?: string }) {
+  async listTopics(groupId: string, filter?: { authorId?: string; status?: string }) {
+    // 종료일 지난 active 스레드를 자동 종료 처리
+    await prisma.discussion.updateMany({
+      where: {
+        groupId,
+        status: 'active',
+        endDate: { not: null, lt: new Date() },
+      },
+      data: { status: 'closed' },
+    });
+
     const where: any = { groupId };
     if (filter?.authorId) {
       where.authorId = filter.authorId;
+    }
+    if (filter?.status) {
+      where.status = filter.status;
     }
 
     const discussions = await prisma.discussion.findMany({
@@ -91,6 +106,9 @@ export const discussionService = {
       title: d.title,
       content: d.content,
       isRecommended: d.isRecommended,
+      isPinned: (d as any).isPinned,
+      status: (d as any).status,
+      endDate: (d as any).endDate,
       createdAt: d.createdAt,
       author: d.author,
       memo: d.memo,
@@ -105,6 +123,11 @@ export const discussionService = {
     });
     if (!discussion) {
       throw new AppError(404, 'NOT_FOUND', '토론 주제를 찾을 수 없습니다');
+    }
+
+    // 종료된 스레드에는 의견 작성 불가
+    if (discussion.status === 'closed') {
+      throw new AppError(403, 'THREAD_CLOSED', '종료된 스레드에는 의견을 작성할 수 없습니다');
     }
 
     // Verify user is a member of the group
@@ -137,6 +160,11 @@ export const discussionService = {
     });
     if (!comment) {
       throw new AppError(404, 'NOT_FOUND', '의견을 찾을 수 없습니다');
+    }
+
+    // 종료된 스레드에는 댓글 작성 불가
+    if (comment.discussion && comment.discussion.status === 'closed') {
+      throw new AppError(403, 'THREAD_CLOSED', '종료된 스레드에는 댓글을 작성할 수 없습니다');
     }
 
     // Verify user is a member of the group
@@ -270,6 +298,65 @@ export const discussionService = {
     });
 
     return discussion;
+  },
+
+  // 종료일 수정 (방장) — 종료된 스레드를 다시 진행중으로 바꿀 수 있음
+  async updateEndDate(discussionId: string, userId: string, endDate: string) {
+    const discussion = await prisma.discussion.findUnique({ where: { id: discussionId } });
+    if (!discussion) throw new AppError(404, 'NOT_FOUND', '스레드를 찾을 수 없습니다');
+
+    const group = await prisma.group.findUnique({ where: { id: discussion.groupId } });
+    if (!group || group.ownerId !== userId) {
+      throw new AppError(403, 'FORBIDDEN', '방장만 종료일을 수정할 수 있습니다');
+    }
+
+    const newEndDate = new Date(endDate);
+    const newStatus = newEndDate >= new Date() ? 'active' : 'closed';
+
+    return prisma.discussion.update({
+      where: { id: discussionId },
+      data: { endDate: newEndDate, status: newStatus },
+    });
+  },
+
+  // 대표 스레드 설정 (방장, 최대 3개)
+  async pinThread(discussionId: string, userId: string) {
+    const discussion = await prisma.discussion.findUnique({ where: { id: discussionId } });
+    if (!discussion) throw new AppError(404, 'NOT_FOUND', '스레드를 찾을 수 없습니다');
+
+    const group = await prisma.group.findUnique({ where: { id: discussion.groupId } });
+    if (!group || group.ownerId !== userId) {
+      throw new AppError(403, 'FORBIDDEN', '방장만 대표 스레드를 설정할 수 있습니다');
+    }
+
+    // 최대 3개 확인
+    const pinnedCount = await prisma.discussion.count({
+      where: { groupId: discussion.groupId, isPinned: true },
+    });
+    if (pinnedCount >= 3) {
+      throw new AppError(400, 'PIN_LIMIT', '대표 스레드는 최대 3개까지 설정할 수 있습니다');
+    }
+
+    return prisma.discussion.update({
+      where: { id: discussionId },
+      data: { isPinned: true },
+    });
+  },
+
+  // 대표 스레드 해제 (방장)
+  async unpinThread(discussionId: string, userId: string) {
+    const discussion = await prisma.discussion.findUnique({ where: { id: discussionId } });
+    if (!discussion) throw new AppError(404, 'NOT_FOUND', '스레드를 찾을 수 없습니다');
+
+    const group = await prisma.group.findUnique({ where: { id: discussion.groupId } });
+    if (!group || group.ownerId !== userId) {
+      throw new AppError(403, 'FORBIDDEN', '방장만 대표 스레드를 해제할 수 있습니다');
+    }
+
+    return prisma.discussion.update({
+      where: { id: discussionId },
+      data: { isPinned: false },
+    });
   },
 };
 

--- a/server/src/validators/index.ts
+++ b/server/src/validators/index.ts
@@ -69,6 +69,7 @@ export const CreateDiscussionSchema = z.object({
   title: z.string().min(1, '토론 주제를 입력해주세요'),
   content: z.string().optional(),
   memoId: z.string().uuid().optional(),
+  endDate: z.string().optional(),
 });
 
 // 의견 작성


### PR DESCRIPTION
## 📝 PR 요약
<!-- 이 PR의 목적과 주요 변경 사항을 간략하게 설명해 주세요. -->
"토론" 페이지를 "책수다"로 리브랜딩하고, 스레드 종료일/상태 관리 및 대표 수다 고정 기능을 추가합니다.

- 스레드 생성 시 종료일 필수 입력
- 종료일 지난 스레드 자동 종료 처리, 의견/댓글 작성 차단
- 진행중인 수다 / 종료된 수다 분류 표시
- 대표 수다 최대 3개 설정 → 책수다 페이지 상단 고정
- 모임장 대시보드에 "책수다 관리" 탭 추가 (종료일 수정, 대표 설정/해제)
- "토론 생성" 탭 삭제
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 적어주세요. 이슈를 자동으로 닫으려면 'Resolves #이슈번호' 형태로 작성하세요. -->
- Resolves: #48 

## 🏷️ PR 분류
<!-- 해당되는 항목의 [ ] 안에 x를 입력하여 [x]로 만들어 주세요. -->
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ✨ 새로운 기능 추가 (New Feature)
- [ ] 🛠️ 코드 리팩토링 (Refactoring)
- [ ] 📚 문서 수정 (Documentation)
- [ ] ⚙️ 설정/빌드 환경 수정 (Configuration/Build)
- [ ] 🧹 단순 수정 (기능에 영향을 주지 않는 오타 수정, 포맷팅 등)

## 🧪 테스트 방법
<!-- 변경 사항이 정상적으로 동작하는지 확인하기 위해 진행한 테스트 방법과 결과를 설명해 주세요. -->
책수다 페이지에서 "책수다 만들기" → 종료일 필수 입력 확인
종료일이 과거인 수다 생성 → "종료된 수다" 섹션에 표시 확인
종료된 수다 클릭 → 의견 작성 폼 대신 "종료되었습니다" 메시지 확인
모임장 대시보드 → "책수다 관리" 탭에서 종료일 수정 (미래 날짜) → 진행중으로 복원 확인
대표 설정 (최대 3개) → 책수다 페이지 상단 "대표 수다" 섹션에 고정 확인
대표 해제 → 상단에서 제거 확인
4개째 대표 설정 시도 → "최대 3개" 에러 확인
## 📸 스크린샷 또는 GIF (선택 사항)
<!-- UI 변경 사항이나 시각적으로 확인할 수 있는 결과물이 있다면 첨부해 주세요. -->
<img width="1086" height="475" alt="image" src="https://github.com/user-attachments/assets/43e63fad-f763-438e-b6d5-a4f8ea7067a3" />
<img width="1016" height="793" alt="image" src="https://github.com/user-attachments/assets/4caacc24-db90-4339-9669-f72b0bb19872" />
<img width="795" height="692" alt="image" src="https://github.com/user-attachments/assets/4fa774b7-5658-4218-9d71-2ea5c4cbb860" />
