### PR TITLE
feat: 스레드 내부 발언권 시스템 (#55) - DiscussionToken 모델 추가

### DIFF
--- a/client/src/api/discussions.ts
+++ b/client/src/api/discussions.ts
@@ -49,4 +49,17 @@ export const discussionsApi = {
 
   unpinThread: (discussionId: string) =>
     apiClient.delete(`/discussions/${discussionId}/pin`),
+
+  // 발언권
+  getTokens: (discussionId: string) =>
+    apiClient.get<{ remaining: number; requested: boolean }>(`/discussions/${discussionId}/tokens`),
+
+  requestTokens: (discussionId: string) =>
+    apiClient.post(`/discussions/${discussionId}/tokens/request`),
+
+  getTokenRequests: (discussionId: string) =>
+    apiClient.get<any[]>(`/discussions/${discussionId}/tokens/requests`),
+
+  grantTokens: (discussionId: string, userId: string, amount: number) =>
+    apiClient.post(`/discussions/${discussionId}/tokens/grant`, { userId, amount }),
 };

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -52,6 +52,8 @@ function DashboardPage() {
   const [threads, setThreads] = useState<Discussion[]>([]);
   const [editingEndDateId, setEditingEndDateId] = useState<string | null>(null);
   const [editingEndDateValue, setEditingEndDateValue] = useState('');
+  const [tokenRequestsForId, setTokenRequestsForId] = useState<string | null>(null);
+  const [tokenRequests, setTokenRequests] = useState<any[]>([]);
   const [newAnnTitle, setNewAnnTitle] = useState('');
   const [newAnnContent, setNewAnnContent] = useState('');
   const [newSchedTitle, setNewSchedTitle] = useState('');
@@ -162,6 +164,31 @@ function DashboardPage() {
       fetchAll();
     } catch (err: any) {
       alert(err.response?.data?.error?.message || '대표 해제에 실패했습니다');
+    }
+  };
+
+  const handleViewTokenRequests = async (discussionId: string) => {
+    if (tokenRequestsForId === discussionId) {
+      setTokenRequestsForId(null);
+      return;
+    }
+    try {
+      const res = await discussionsApi.getTokenRequests(discussionId);
+      setTokenRequests(res.data);
+      setTokenRequestsForId(discussionId);
+    } catch {
+      setTokenRequests([]);
+      setTokenRequestsForId(discussionId);
+    }
+  };
+
+  const handleGrantTokens = async (discussionId: string, userId: string) => {
+    try {
+      await discussionsApi.grantTokens(discussionId, userId, 5);
+      alert('발언권 5개를 지급했습니다');
+      handleViewTokenRequests(discussionId);
+    } catch (err: any) {
+      alert(err.response?.data?.error?.message || '지급에 실패했습니다');
     }
   };
 
@@ -301,11 +328,11 @@ function DashboardPage() {
       case 'threads':
         return (
           <div style={styles.section}>
-            <div style={styles.sectionTitle}>📚 스레드 관리</div>
-            <div style={{ fontSize: 13, color: '#718096', marginBottom: 16 }}>스레드 종료일 수정, 대표 스레드 설정/해제를 관리합니다.</div>
+            <div style={styles.sectionTitle}>📚 책수다 관리</div>
+            <div style={{ fontSize: 13, color: '#718096', marginBottom: 16 }}>스레드 종료일 수정, 대표 수다 설정/해제, 발언권 관리를 합니다.</div>
 
             {threads.length === 0 ? (
-              <div style={{ color: '#a0aec0', fontSize: 13 }}>아직 생성된 스레드가 없습니다</div>
+              <div style={{ color: '#a0aec0', fontSize: 13 }}>아직 생성된 수다가 없습니다</div>
             ) : threads.map((d: any) => (
               <div key={d.id} style={{ padding: '12px 0', borderBottom: '1px solid #f0f0f0' }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
@@ -326,6 +353,7 @@ function DashboardPage() {
                     ) : (
                       <button style={{ ...styles.btn, ...styles.btnPrimary, padding: '4px 8px', fontSize: 11 }} onClick={() => handlePinThread(d.id)}>대표 설정</button>
                     )}
+                    <button style={{ ...styles.btn, ...styles.btnSecondary, padding: '4px 8px', fontSize: 11 }} onClick={() => handleViewTokenRequests(d.id)}>🎫 발언권</button>
                   </div>
                 </div>
                 {editingEndDateId === d.id && (
@@ -333,6 +361,20 @@ function DashboardPage() {
                     <input type="date" style={{ ...styles.input, marginBottom: 0, flex: 1 }} value={editingEndDateValue} onChange={e => setEditingEndDateValue(e.target.value)} />
                     <button style={{ ...styles.btn, ...styles.btnPrimary, padding: '6px 12px', fontSize: 12 }} onClick={handleSaveEndDate}>저장</button>
                     <button style={{ ...styles.btn, ...styles.btnSecondary, padding: '6px 12px', fontSize: 12 }} onClick={() => setEditingEndDateId(null)}>취소</button>
+                  </div>
+                )}
+                {tokenRequestsForId === d.id && (
+                  <div style={{ marginTop: 8, padding: '12px', backgroundColor: '#f7fafc', borderRadius: 6 }}>
+                    <div style={{ fontSize: 12, fontWeight: 600, marginBottom: 8 }}>🎫 발언권 요청 목록</div>
+                    {tokenRequests.length === 0 ? (
+                      <div style={{ fontSize: 12, color: '#a0aec0' }}>요청이 없습니다</div>
+                    ) : tokenRequests.map((req: any) => (
+                      <div key={req.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '4px 0', fontSize: 12 }}>
+                        <span>{req.user.nickname} (남은 발언권: {req.remaining})</span>
+                        <button style={{ ...styles.btn, ...styles.btnPrimary, padding: '2px 8px', fontSize: 11 }} onClick={() => handleGrantTokens(d.id, req.userId)}>+5 지급</button>
+                      </div>
+                    ))}
+                    <button style={{ ...styles.btn, ...styles.btnSecondary, padding: '4px 8px', fontSize: 11, marginTop: 8 }} onClick={() => setTokenRequestsForId(null)}>닫기</button>
                   </div>
                 )}
               </div>

--- a/client/src/pages/DiscussionThreadPage.tsx
+++ b/client/src/pages/DiscussionThreadPage.tsx
@@ -219,6 +219,8 @@ function DiscussionThreadPage() {
   // Comment form
   const [newComment, setNewComment] = useState('');
   const [submittingComment, setSubmittingComment] = useState(false);
+  const [tokenRemaining, setTokenRemaining] = useState<number | null>(null);
+  const [tokenRequested, setTokenRequested] = useState(false);
 
   // Reply forms
   const [replyingTo, setReplyingTo] = useState<string | null>(null);
@@ -239,6 +241,13 @@ function DiscussionThreadPage() {
       ]);
       setTopic(topicRes.data);
       setComments(commentsRes.data);
+
+      // 발언권 조회
+      if (discussionId) {
+        const tokenRes = await discussionsApi.getTokens(discussionId).catch(() => ({ data: { remaining: 10, requested: false } }));
+        setTokenRemaining(tokenRes.data.remaining);
+        setTokenRequested(tokenRes.data.requested);
+      }
 
       // Check if current user is group owner
       if (topicRes.data?.groupId) {
@@ -432,25 +441,62 @@ function DiscussionThreadPage() {
         </div>
       ) : (
         <div style={styles.section}>
-          <div style={styles.sectionTitle}>의견 작성</div>
-          <form onSubmit={handleAddComment}>
-            <textarea
-              style={styles.textarea}
-              rows={3}
-              value={newComment}
-              onChange={(e) => setNewComment(e.target.value)}
-              placeholder="의견을 작성해주세요"
-            />
-            <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 8 }}>
-              <button
-                type="submit"
-                style={styles.submitBtn}
-                disabled={submittingComment}
-              >
-                {submittingComment ? '작성 중...' : '의견 작성'}
-              </button>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+            <div style={styles.sectionTitle}>의견 작성</div>
+            {!isOwner && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13, fontWeight: 500, color: tokenRemaining && tokenRemaining > 3 ? '#48bb78' : '#e53e3e' }}>
+                🎫 내 발언권: {tokenRemaining ?? '...'}개
+                <span style={{ position: 'relative', display: 'inline-block', cursor: 'help' }}
+                  onMouseEnter={e => { const tip = e.currentTarget.querySelector('[data-tip]') as HTMLElement; if (tip) tip.style.display = 'block'; }}
+                  onMouseLeave={e => { const tip = e.currentTarget.querySelector('[data-tip]') as HTMLElement; if (tip) tip.style.display = 'none'; }}
+                >
+                  <span style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 18, height: 18, borderRadius: '50%', backgroundColor: '#e2e8f0', color: '#4a5568', fontSize: 11, fontWeight: 700 }}>?</span>
+                  <span data-tip="" style={{ display: 'none', position: 'absolute', bottom: '130%', left: '50%', transform: 'translateX(-50%)', backgroundColor: '#2d3748', color: '#fff', padding: '8px 12px', borderRadius: 8, fontSize: 12, lineHeight: 1.5, whiteSpace: 'nowrap', boxShadow: '0 4px 12px rgba(0,0,0,0.15)', zIndex: 10 }}>
+                    의견/댓글 작성 시 발언권이 차감되며,<br/>삭제해도 돌려받을 수 없으니 신중하게 작성해주세요!
+                  </span>
+                </span>
+                {tokenRemaining !== null && tokenRemaining <= 0 && !tokenRequested && (
+                  <button
+                    style={{ marginLeft: 6, padding: '2px 8px', fontSize: 11, border: '1px solid #3182ce', borderRadius: 4, backgroundColor: '#fff', color: '#3182ce', cursor: 'pointer' }}
+                    onClick={async () => {
+                      try {
+                        await discussionsApi.requestTokens(discussionId!);
+                        setTokenRequested(true);
+                        alert('발언권 추가를 요청했습니다.');
+                      } catch { alert('이미 요청했습니다.'); }
+                    }}
+                  >
+                    추가 요청
+                  </button>
+                )}
+                {tokenRequested && <span style={{ marginLeft: 4, fontSize: 11, color: '#718096' }}>(요청됨)</span>}
+              </div>
+            )}
+          </div>
+          {!isOwner && tokenRemaining !== null && tokenRemaining <= 0 ? (
+            <div style={{ textAlign: 'center', padding: '16px', color: '#e53e3e', fontSize: 13 }}>
+              발언권이 부족합니다. 모임장에게 추가 요청하세요.
             </div>
-          </form>
+          ) : (
+            <form onSubmit={handleAddComment}>
+              <textarea
+                style={styles.textarea}
+                rows={3}
+                value={newComment}
+                onChange={(e) => setNewComment(e.target.value)}
+                placeholder="의견을 작성해주세요"
+              />
+              <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 8 }}>
+                <button
+                  type="submit"
+                  style={styles.submitBtn}
+                  disabled={submittingComment}
+                >
+                  {submittingComment ? '작성 중...' : '의견 작성'}
+                </button>
+              </div>
+            </form>
+          )}
         </div>
       )}
 

--- a/docs/feature-discussion-token-system.md
+++ b/docs/feature-discussion-token-system.md
@@ -1,0 +1,68 @@
+# 스레드 내부 발언권 시스템
+
+관련 이슈: #55
+브랜치: `55-feature-discussion-token-system`
+
+## 개요
+
+스레드(책수다) 내에서 참여자별 발언권을 관리하여, 과도한 발언 독점을 방지하고 신중한 토론 참여를 유도합니다.
+
+## 핵심 규칙
+
+- 스레드 참여 시 기본 발언권 **10개** 지급
+- 의견 또는 댓글 작성 시 **1개 차감**
+- 발언권 0이면 해당 스레드에서 작성 불가
+- **삭제해도 발언권 미환불**
+- **모임장은 발언권 제한 없음** (차감 안 됨, UI에도 표시 안 됨)
+
+## 기능
+
+### 참여자
+- 스레드 상세 페이지에서 "🎫 내 발언권: N개" 확인
+- `?` 버튼 hover 시 커스텀 툴팁으로 규칙 설명
+- 발언권 0일 때 "추가 요청" 버튼 → 모임장에게 요청
+- 요청 후 "(요청됨)" 표시
+
+### 모임장
+- 대시보드 "책수다 관리" 탭에서 각 스레드의 "🎫 발언권" 버튼 클릭
+- 발언권 요청 목록 확인 (요청한 참여자 닉네임, 남은 발언권)
+- "+5 지급" 버튼으로 발언권 추가 지급 → 요청 상태 해제
+
+## DB 스키마
+
+```
+model DiscussionToken {
+  id           String   @id @default(uuid())
+  discussionId String   @map("discussion_id")
+  userId       String   @map("user_id")
+  remaining    Int      @default(10)
+  requested    Boolean  @default(false)
+  createdAt    DateTime @default(now()) @map("created_at")
+
+  @@unique([discussionId, userId])
+  @@map("discussion_tokens")
+}
+```
+
+## API 엔드포인트
+
+| 메서드 | 경로 | 설명 | 권한 |
+|--------|------|------|------|
+| GET | `/api/discussions/:id/tokens` | 내 발언권 조회 | 로그인 |
+| POST | `/api/discussions/:id/tokens/request` | 발언권 추가 요청 | 로그인 |
+| GET | `/api/discussions/:id/tokens/requests` | 요청 목록 조회 | 방장 |
+| POST | `/api/discussions/:id/tokens/grant` | 발언권 지급 | 방장 |
+
+## 변경된 파일
+
+### 백엔드
+- `server/prisma/schema.prisma` — DiscussionToken 모델 추가
+- `server/src/services/token.service.ts` (신규) — 발언권 조회/차감/요청/지급
+- `server/src/routes/token.routes.ts` (신규) — 발언권 API 엔드포인트
+- `server/src/services/discussion.service.ts` — addComment/addReply에서 발언권 차감 연동
+- `server/src/index.ts` — tokenRouter 등록
+
+### 프론트엔드
+- `client/src/api/discussions.ts` — getTokens, requestTokens, getTokenRequests, grantTokens 추가
+- `client/src/pages/DiscussionThreadPage.tsx` — 발언권 UI (표시, 툴팁, 요청, 부족 시 차단)
+- `client/src/pages/DashboardPage.tsx` — 책수다 관리 탭에 발언권 요청 확인/지급 기능

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -29,6 +29,7 @@ model User {
   replies      Reply[]
   ownedGroups  Group[]      @relation("GroupOwner")
   bans         GroupBan[]
+  tokens       DiscussionToken[]
 
   @@map("users")
 }
@@ -123,12 +124,28 @@ model Discussion {
   endDate       DateTime? @map("end_date") @db.Date
   createdAt     DateTime  @default(now()) @map("created_at")
 
-  group    Group     @relation(fields: [groupId], references: [id])
-  author   User      @relation(fields: [authorId], references: [id])
-  memo     Memo?     @relation(fields: [memoId], references: [id])
+  group    Group              @relation(fields: [groupId], references: [id])
+  author   User               @relation(fields: [authorId], references: [id])
+  memo     Memo?              @relation(fields: [memoId], references: [id])
   comments Comment[]
+  tokens   DiscussionToken[]
 
   @@map("discussions")
+}
+
+model DiscussionToken {
+  id           String   @id @default(uuid())
+  discussionId String   @map("discussion_id")
+  userId       String   @map("user_id")
+  remaining    Int      @default(10)
+  requested    Boolean  @default(false)
+  createdAt    DateTime @default(now()) @map("created_at")
+
+  discussion Discussion @relation(fields: [discussionId], references: [id])
+  user       User       @relation(fields: [userId], references: [id])
+
+  @@unique([discussionId, userId])
+  @@map("discussion_tokens")
 }
 
 model Comment {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -11,6 +11,7 @@ import discussionRouter from './routes/discussion.routes';
 import mypageRouter from './routes/mypage.routes';
 import dashboardRouter from './routes/dashboard.routes';
 import aiRouter from './routes/ai.routes';
+import tokenRouter from './routes/token.routes';
 import { globalErrorHandler } from './middleware/errorHandler';
 
 const app = express();
@@ -50,6 +51,7 @@ app.use('/api', discussionRouter);
 app.use('/api/me', mypageRouter);
 app.use('/api', dashboardRouter);
 app.use('/api', aiRouter);
+app.use('/api', tokenRouter);
 
 // 글로벌 에러 핸들러 (모든 라우터 뒤에 등록)
 app.use(globalErrorHandler);

--- a/server/src/routes/token.routes.ts
+++ b/server/src/routes/token.routes.ts
@@ -1,0 +1,69 @@
+import { Router, Response } from 'express';
+import { tokenService } from '../services/token.service';
+import { AppError } from '../services/auth.service';
+import { authMiddleware, AuthRequest } from '../middleware/auth.middleware';
+
+const router = Router();
+
+// GET /api/discussions/:id/tokens - 내 발언권 조회
+router.get('/discussions/:id/tokens', authMiddleware, async (req: AuthRequest, res: Response) => {
+  try {
+    const token = await tokenService.getOrCreate(req.params.id as string, req.user!.userId);
+    res.json(token);
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: { code: err.code, message: err.message } });
+      return;
+    }
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: '서버 오류가 발생했습니다' } });
+  }
+});
+
+// POST /api/discussions/:id/tokens/request - 발언권 추가 요청
+router.post('/discussions/:id/tokens/request', authMiddleware, async (req: AuthRequest, res: Response) => {
+  try {
+    const token = await tokenService.requestTokens(req.params.id as string, req.user!.userId);
+    res.json(token);
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: { code: err.code, message: err.message } });
+      return;
+    }
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: '서버 오류가 발생했습니다' } });
+  }
+});
+
+// GET /api/discussions/:id/tokens/requests - 발언권 요청 목록 (모임장)
+router.get('/discussions/:id/tokens/requests', authMiddleware, async (req: AuthRequest, res: Response) => {
+  try {
+    const requests = await tokenService.listRequests(req.params.id as string, req.user!.userId);
+    res.json(requests);
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: { code: err.code, message: err.message } });
+      return;
+    }
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: '서버 오류가 발생했습니다' } });
+  }
+});
+
+// POST /api/discussions/:id/tokens/grant - 발언권 지급 (모임장)
+router.post('/discussions/:id/tokens/grant', authMiddleware, async (req: AuthRequest, res: Response) => {
+  try {
+    const { userId, amount } = req.body;
+    if (!userId || !amount || amount < 1) {
+      res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: '대상 사용자와 지급 수량을 입력해주세요' } });
+      return;
+    }
+    const token = await tokenService.grantTokens(req.params.id as string, userId, amount, req.user!.userId);
+    res.json(token);
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: { code: err.code, message: err.message } });
+      return;
+    }
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: '서버 오류가 발생했습니다' } });
+  }
+});
+
+export default router;

--- a/server/src/services/discussion.service.ts
+++ b/server/src/services/discussion.service.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from '@prisma/client';
 import { AppError } from './auth.service';
 import { CreateDiscussionInput, CreateCommentInput } from '../validators';
+import { tokenService } from './token.service';
 
 const prisma = new PrismaClient();
 
@@ -130,6 +131,9 @@ export const discussionService = {
       throw new AppError(403, 'THREAD_CLOSED', '종료된 스레드에는 의견을 작성할 수 없습니다');
     }
 
+    // 발언권 차감
+    await tokenService.consume(discussionId, userId);
+
     // Verify user is a member of the group
     const member = await prisma.groupMember.findUnique({
       where: { groupId_userId: { groupId: discussion.groupId, userId } },
@@ -165,6 +169,11 @@ export const discussionService = {
     // 종료된 스레드에는 댓글 작성 불가
     if (comment.discussion && comment.discussion.status === 'closed') {
       throw new AppError(403, 'THREAD_CLOSED', '종료된 스레드에는 댓글을 작성할 수 없습니다');
+    }
+
+    // 발언권 차감
+    if (comment.discussion) {
+      await tokenService.consume(comment.discussion.id, userId);
     }
 
     // Verify user is a member of the group

--- a/server/src/services/token.service.ts
+++ b/server/src/services/token.service.ts
@@ -1,0 +1,84 @@
+import { PrismaClient } from '@prisma/client';
+import { AppError } from './auth.service';
+
+const prisma = new PrismaClient();
+const DEFAULT_TOKENS = 10;
+
+export const tokenService = {
+  // 발언권 조회 (없으면 자동 생성)
+  async getOrCreate(discussionId: string, userId: string) {
+    let token = await prisma.discussionToken.findUnique({
+      where: { discussionId_userId: { discussionId, userId } },
+    });
+    if (!token) {
+      token = await prisma.discussionToken.create({
+        data: { discussionId, userId, remaining: DEFAULT_TOKENS },
+      });
+    }
+    return token;
+  },
+
+  // 발언권 차감 (의견/댓글 작성 시 호출)
+  async consume(discussionId: string, userId: string) {
+    // 모임장은 발언권 제한 없음
+    const discussion = await prisma.discussion.findUnique({ where: { id: discussionId } });
+    if (discussion) {
+      const group = await prisma.group.findUnique({ where: { id: discussion.groupId } });
+      if (group && group.ownerId === userId) return; // 모임장은 차감 안 함
+    }
+
+    const token = await this.getOrCreate(discussionId, userId);
+    if (token.remaining <= 0) {
+      throw new AppError(403, 'NO_TOKENS', '발언권이 부족합니다. 모임장에게 추가 요청하세요.');
+    }
+    return prisma.discussionToken.update({
+      where: { discussionId_userId: { discussionId, userId } },
+      data: { remaining: token.remaining - 1 },
+    });
+  },
+
+  // 발언권 추가 요청 (참여자 → 모임장)
+  async requestTokens(discussionId: string, userId: string) {
+    const token = await this.getOrCreate(discussionId, userId);
+    if (token.requested) {
+      throw new AppError(409, 'ALREADY_REQUESTED', '이미 발언권을 요청했습니다.');
+    }
+    return prisma.discussionToken.update({
+      where: { discussionId_userId: { discussionId, userId } },
+      data: { requested: true },
+    });
+  },
+
+  // 발언권 지급 (모임장)
+  async grantTokens(discussionId: string, targetUserId: string, amount: number, ownerId: string) {
+    const discussion = await prisma.discussion.findUnique({ where: { id: discussionId } });
+    if (!discussion) throw new AppError(404, 'NOT_FOUND', '스레드를 찾을 수 없습니다');
+
+    const group = await prisma.group.findUnique({ where: { id: discussion.groupId } });
+    if (!group || group.ownerId !== ownerId) {
+      throw new AppError(403, 'FORBIDDEN', '방장만 발언권을 지급할 수 있습니다');
+    }
+
+    const token = await this.getOrCreate(discussionId, targetUserId);
+    return prisma.discussionToken.update({
+      where: { discussionId_userId: { discussionId, userId: targetUserId } },
+      data: { remaining: token.remaining + amount, requested: false },
+    });
+  },
+
+  // 스레드의 발언권 요청 목록 조회 (모임장용)
+  async listRequests(discussionId: string, ownerId: string) {
+    const discussion = await prisma.discussion.findUnique({ where: { id: discussionId } });
+    if (!discussion) throw new AppError(404, 'NOT_FOUND', '스레드를 찾을 수 없습니다');
+
+    const group = await prisma.group.findUnique({ where: { id: discussion.groupId } });
+    if (!group || group.ownerId !== ownerId) {
+      throw new AppError(403, 'FORBIDDEN', '방장만 요청 목록을 조회할 수 있습니다');
+    }
+
+    return prisma.discussionToken.findMany({
+      where: { discussionId, requested: true },
+      include: { user: { select: { id: true, nickname: true } } },
+    });
+  },
+};


### PR DESCRIPTION
## 📝 PR 요약
<!-- 이 PR의 목적과 주요 변경 사항을 간략하게 설명해 주세요. -->
스레드 내부 발언권 시스템을 구현합니다. 참여자별 발언권을 관리하여 과도한 발언 독점을 방지하고 신중한 발언 참여를 유도합니다.

- 스레드 참여 시 기본 발언권 10개 지급
- 의견/댓글 작성 시 1개 차감, 0이면 작성 차단
- 삭제해도 발언권 미환불
- 모임장은 발언권 제한 없음 (UI에도 미표시)
- 참여자가 모임장에게 발언권 추가 요청 가능
- 모임장이 대시보드에서 요청 확인 및 발언권 지급
- ? 버튼 hover 시 커스텀 툴팁으로 규칙 안내
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 적어주세요. 이슈를 자동으로 닫으려면 'Resolves #이슈번호' 형태로 작성하세요. -->
- Resolves: #55

## 🏷️ PR 분류
<!-- 해당되는 항목의 [ ] 안에 x를 입력하여 [x]로 만들어 주세요. -->
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ✨ 새로운 기능 추가 (New Feature)
- [ ] 🛠️ 코드 리팩토링 (Refactoring)
- [ ] 📚 문서 수정 (Documentation)
- [ ] ⚙️ 설정/빌드 환경 수정 (Configuration/Build)
- [ ] 🧹 단순 수정 (기능에 영향을 주지 않는 오타 수정, 포맷팅 등)

## 🧪 테스트 방법
<!-- 변경 사항이 정상적으로 동작하는지 확인하기 위해 진행한 테스트 방법과 결과를 설명해 주세요. -->

1. 일반 참여자로 스레드 접속 → "🎫 내 발언권: 10개" 확인
2. 의견 작성 → 발언권 9개로 차감 확인
3. 댓글 작성 → 발언권 8개로 차감 확인
4. 발언권 0까지 소진 → "발언권이 부족합니다" 메시지 + 작성 폼 비활성화 확인
5. "추가 요청" 클릭 → "(요청됨)" 표시 확인
6. 모임장으로 대시보드 → "책수다 관리" 탭 → 해당 스레드 "🎫 발언권" 클릭 → 요청 목록 확인
7. "+5 지급" 클릭 → 참여자 발언권 복원 확인
8. 모임장으로 스레드 접속 → 발언권 표시 없이 무제한 작성 확인

## 📸 스크린샷 또는 GIF (선택 사항)
<!-- UI 변경 사항이나 시각적으로 확인할 수 있는 결과물이 있다면 첨부해 주세요. -->
<img width="1122" height="252" alt="image" src="https://github.com/user-attachments/assets/ecaebf8f-3f61-4606-8a4f-e14e8556652e" />
<img width="1087" height="212" alt="image" src="https://github.com/user-attachments/assets/ba891eff-2446-465f-8b9d-5ae179c6a60b" />
