### PR TITLE
fix: 책수다 스레드 내부 네비게이션 수정

### DIFF
--- a/client/src/pages/DiscussionThreadPage.tsx
+++ b/client/src/pages/DiscussionThreadPage.tsx
@@ -316,7 +316,12 @@ function DiscussionThreadPage() {
 
   return (
     <div style={styles.container}>
-      <Link to="/" style={styles.backLink}>← 홈으로</Link>
+      <Link
+        to={topic?.groupId ? `/groups/${topic.groupId}/discussions` : '/'}
+        style={styles.backLink}
+      >
+        ← 책수다 목록으로
+      </Link>
 
       {/* Topic Header */}
       <div style={styles.topicSection}>


### PR DESCRIPTION
## 📝 PR 요약
책수다 스레드 네부 내비게이션이 '홈으로' 가도록 되어있어 불편합니다.
DiscussionThreadPage의 내비게이션 경로와 이름만 수정하였습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 적어주세요. 이슈를 자동으로 닫으려면 'Resolves #이슈번호' 형태로 작성하세요. -->
- Resolves: #51 

## 🏷️ PR 분류
<!-- 해당되는 항목의 [ ] 안에 x를 입력하여 [x]로 만들어 주세요. -->
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ✨ 새로운 기능 추가 (New Feature)
- [ ] 🛠️ 코드 리팩토링 (Refactoring)
- [ ] 📚 문서 수정 (Documentation)
- [ ] ⚙️ 설정/빌드 환경 수정 (Configuration/Build)
- [ ] 🧹 단순 수정 (기능에 영향을 주지 않는 오타 수정, 포맷팅 등)

## 🧪 테스트 방법
<!-- 변경 사항이 정상적으로 동작하는지 확인하기 위해 진행한 테스트 방법과 결과를 설명해 주세요. -->

## 📸 스크린샷 또는 GIF (선택 사항)
이제 홈이 아니라 책수다 목록으로 돌아가게 됩니다.
<img width="808" height="683" alt="image" src="https://github.com/user-attachments/assets/8f6c8ab9-5d6b-4d96-8078-a13ea11f7cd1" />

<img width="829" height="447" alt="image" src="https://github.com/user-attachments/assets/7733c974-046b-4070-98bd-1bd745d3909f" />
