### PR TITLE
feat: 스레드 종료 시 인사이트 자동 생성 및 카드 공유 기능

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "axios": "^1.7.7",
+        "html-to-image": "^1.11.13",
         "marked": "^18.0.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1727,6 +1728,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^1.7.7",
+    "html-to-image": "^1.11.13",
     "marked": "^18.0.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/client/src/api/ai.ts
+++ b/client/src/api/ai.ts
@@ -14,4 +14,14 @@ export const aiApi = {
 
   generateInsight: (groupId: string) =>
     apiClient.post<{ insight: string }>(`/groups/${groupId}/ai/insight`),
+
+  // 인사이트 저장 기능
+  generateAndSaveInsight: (groupId: string) =>
+    apiClient.post<any>(`/groups/${groupId}/insights`),
+
+  getSavedInsight: (groupId: string) =>
+    apiClient.get<any>(`/groups/${groupId}/insights`),
+
+  getMyInsights: () =>
+    apiClient.get<any[]>('/me/insights'),
 };

--- a/client/src/components/InsightCard.tsx
+++ b/client/src/components/InsightCard.tsx
@@ -1,0 +1,154 @@
+import { useRef } from 'react';
+import { toPng } from 'html-to-image';
+
+interface InsightData {
+  bookTitle: string;
+  bookAuthor?: string;
+  bookCoverUrl?: string;
+  summary: string;
+  keywords: string[];
+  highlights: string[];
+  takeaway: string;
+  memoCount: number;
+  discussionCount: number;
+  commentCount: number;
+  createdAt: string;
+}
+
+interface InsightCardProps {
+  insight: InsightData;
+}
+
+export function InsightCard({ insight }: InsightCardProps) {
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  const handleExportImage = async () => {
+    if (!cardRef.current) return;
+    try {
+      const dataUrl = await toPng(cardRef.current, { pixelRatio: 2 });
+      const link = document.createElement('a');
+      link.download = `insight-${insight.bookTitle}.png`;
+      link.href = dataUrl;
+      link.click();
+    } catch {
+      alert('이미지 저장에 실패했습니다.');
+    }
+  };
+
+  const handleCopyForKakao = async () => {
+    if (!cardRef.current) return;
+    try {
+      const dataUrl = await toPng(cardRef.current, { pixelRatio: 2 });
+      const blob = await (await fetch(dataUrl)).blob();
+      await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+      alert('클립보드에 복사되었습니다! 카카오톡에 붙여넣기(Ctrl+V)하세요.');
+    } catch {
+      alert('클립보드 복사에 실패했습니다. 이미지로 저장 후 공유해주세요.');
+    }
+  };
+
+  const handleCopyForDiscord = async () => {
+    if (!cardRef.current) return;
+    try {
+      const dataUrl = await toPng(cardRef.current, { pixelRatio: 2 });
+      const blob = await (await fetch(dataUrl)).blob();
+      await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+      alert('클립보드에 복사되었습니다! 디스코드에 붙여넣기(Ctrl+V)하세요.');
+    } catch {
+      alert('클립보드 복사에 실패했습니다. 이미지로 저장 후 공유해주세요.');
+    }
+  };
+
+  return (
+    <div>
+      {/* Card */}
+      <div ref={cardRef} style={{
+        background: 'linear-gradient(145deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%)',
+        borderRadius: 20,
+        padding: '32px 28px',
+        color: '#fff',
+        maxWidth: 420,
+        position: 'relative',
+        overflow: 'hidden',
+      }}>
+        {/* Decorative circle */}
+        <div style={{ position: 'absolute', top: -30, right: -30, width: 120, height: 120, borderRadius: '50%', background: 'rgba(102,126,234,0.15)' }} />
+        <div style={{ position: 'absolute', bottom: -20, left: -20, width: 80, height: 80, borderRadius: '50%', background: 'rgba(118,75,162,0.1)' }} />
+
+        {/* Header */}
+        <div style={{ position: 'relative', marginBottom: 20 }}>
+          <div style={{ fontSize: 11, textTransform: 'uppercase' as const, letterSpacing: 2, opacity: 0.5, marginBottom: 8 }}>READING INSIGHT</div>
+          <div style={{ fontSize: 18, fontWeight: 700, lineHeight: 1.3 }}>{insight.bookTitle}</div>
+          {insight.bookAuthor && <div style={{ fontSize: 13, opacity: 0.6, marginTop: 4 }}>{insight.bookAuthor}</div>}
+        </div>
+
+        {/* Takeaway - 핵심 한 줄 */}
+        {insight.takeaway && (
+          <div style={{
+            fontSize: 15,
+            fontWeight: 500,
+            lineHeight: 1.6,
+            marginBottom: 20,
+            padding: '12px 16px',
+            background: 'rgba(255,255,255,0.08)',
+            borderRadius: 10,
+            borderLeft: '3px solid #667eea',
+          }}>
+            "{insight.takeaway}"
+          </div>
+        )}
+
+        {/* Summary */}
+        {insight.summary && (
+          <div style={{ fontSize: 13, lineHeight: 1.7, opacity: 0.85, marginBottom: 16 }}>
+            {insight.summary}
+          </div>
+        )}
+
+        {/* Highlights */}
+        {insight.highlights && insight.highlights.length > 0 && (
+          <div style={{ marginBottom: 20 }}>
+            {insight.highlights.map((h, i) => (
+              <div key={i} style={{ fontSize: 13, lineHeight: 1.6, marginBottom: 6, paddingLeft: 14, position: 'relative' as const, opacity: 0.9 }}>
+                <span style={{ position: 'absolute', left: 0 }}>•</span>{h}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Keywords */}
+        <div style={{ display: 'flex', flexWrap: 'wrap' as const, gap: 6, marginBottom: 20 }}>
+          {insight.keywords.slice(0, 5).map((kw, i) => (
+            <span key={i} style={{
+              padding: '4px 12px',
+              background: 'rgba(102,126,234,0.25)',
+              borderRadius: 20,
+              fontSize: 12,
+              fontWeight: 500,
+            }}>#{kw}</span>
+          ))}
+        </div>
+
+        {/* Stats */}
+        <div style={{ display: 'flex', gap: 16, fontSize: 12, opacity: 0.6, paddingTop: 12, borderTop: '1px solid rgba(255,255,255,0.1)' }}>
+          <span>📝 메모 {insight.memoCount}개</span>
+          <span>💬 토론 {insight.discussionCount}개</span>
+          <span>🗨️ 의견 {insight.commentCount}개</span>
+        </div>
+      </div>
+
+      {/* Action Buttons */}
+      <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+        <button onClick={handleExportImage} style={{ padding: '8px 16px', backgroundColor: '#2d3748', color: '#fff', border: 'none', borderRadius: 8, fontSize: 13, fontWeight: 500, cursor: 'pointer' }}>
+          📷 저장
+        </button>
+        <button onClick={handleCopyForKakao} style={{ padding: '8px 16px', backgroundColor: '#FEE500', color: '#3C1E1E', border: 'none', borderRadius: 8, fontSize: 13, fontWeight: 500, cursor: 'pointer' }}>
+          💬 카톡 공유
+        </button>
+        <button onClick={handleCopyForDiscord} style={{ padding: '8px 16px', backgroundColor: '#5865F2', color: '#fff', border: 'none', borderRadius: 8, fontSize: 13, fontWeight: 500, cursor: 'pointer' }}>
+          🎮 디스코드 공유
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/DiscussionThreadPage.tsx
+++ b/client/src/pages/DiscussionThreadPage.tsx
@@ -6,6 +6,7 @@ import { groupsApi } from '../api/groups';
 import { useAuthStore } from '../stores/authStore';
 import { aiApi } from '../api/ai';
 import { Markdown } from '../components/Markdown';
+import { InsightCard } from '../components/InsightCard';
 import { timeAgo } from '../utils/timeAgo';
 import type { Comment as CommentType, Discussion } from '../types';
 
@@ -231,6 +232,9 @@ function DiscussionThreadPage() {
   const [aiSummary, setAiSummary] = useState('');
   const [aiLoading, setAiLoading] = useState(false);
 
+  // Thread insight (종료 시 자동 생성된 인사이트)
+  const [threadInsight, setThreadInsight] = useState<any>(null);
+
   const fetchData = async () => {
     if (!discussionId) return;
     setLoading(true);
@@ -254,6 +258,12 @@ function DiscussionThreadPage() {
         const groupRes = await groupsApi.getDetail(topicRes.data.groupId).catch(() => ({ data: null }));
         if (groupRes.data) {
           setIsOwner(groupRes.data.ownerId === currentUserId);
+        }
+
+        // 종료된 스레드면 인사이트 불러오기
+        if (topicRes.data && (topicRes.data as any).status === 'closed' && topicRes.data.groupId) {
+          const insightRes = await aiApi.getSavedInsight(topicRes.data.groupId).catch(() => ({ data: null }));
+          if (insightRes.data) setThreadInsight(insightRes.data);
         }
       }
     } catch { /* ignore */ }
@@ -348,6 +358,17 @@ function DiscussionThreadPage() {
           </div>
         )}
       </div>
+
+      {/* Thread Insight (종료된 스레드) */}
+      {threadInsight && (topic as any)?.status === 'closed' && (
+        <div style={styles.section}>
+          <div style={styles.sectionTitle}>📊 인사이트</div>
+          <div style={{ fontSize: 13, color: '#718096', marginBottom: 12 }}>
+            이 스레드가 종료되어 AI가 자동으로 생성한 인사이트입니다.
+          </div>
+          <InsightCard insight={threadInsight} />
+        </div>
+      )}
 
       {/* Comments List */}
       <div style={styles.section}>

--- a/client/src/pages/MyPage.tsx
+++ b/client/src/pages/MyPage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { mypageApi } from '../api/mypage';
 import { aiApi } from '../api/ai';
-import { Markdown } from '../components/Markdown';
+import { InsightCard } from '../components/InsightCard';
 import { useAuthStore } from '../stores/authStore';
 import type { GroupCard, Memo, Discussion, User } from '../types';
 
@@ -23,8 +23,9 @@ function MyPage() {
   const [recommendedGroups, setRecommendedGroups] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const [insightGroupId, setInsightGroupId] = useState<string | null>(null);
-  const [insight, setInsight] = useState('');
+  const [insight, setInsight] = useState<any>(null);
   const [insightLoading, setInsightLoading] = useState(false);
+  const [generatedGroups, setGeneratedGroups] = useState<Set<string>>(new Set());
 
   // 닉네임 수정 상태
   const [editingNickname, setEditingNickname] = useState(false);
@@ -38,12 +39,13 @@ function MyPage() {
     const fetchData = async () => {
       setLoading(true);
       try {
-        const [pRes, gRes, mRes, dRes, recRes] = await Promise.all([
+        const [pRes, gRes, mRes, dRes, recRes, insightsRes] = await Promise.all([
           mypageApi.getProfile().catch(() => ({ data: null })),
           mypageApi.getGroups().catch(() => ({ data: [] })),
           mypageApi.getMemos().catch(() => ({ data: [] })),
           mypageApi.getDiscussions().catch(() => ({ data: [] })),
           mypageApi.getRecommendedGroups().catch(() => ({ data: [] })),
+          aiApi.getMyInsights().catch(() => ({ data: [] })),
         ]);
         setProfile(pRes.data);
         if (pRes.data) setUser(pRes.data);
@@ -51,6 +53,9 @@ function MyPage() {
         setMemos(mRes.data);
         setDiscussions(dRes.data);
         setRecommendedGroups(recRes.data);
+        // 이미 인사이트가 생성된 모임 ID 추적
+        const existingIds = new Set<string>((insightsRes.data || []).map((i: any) => i.groupId));
+        setGeneratedGroups(existingIds);
       } finally {
         setLoading(false);
       }
@@ -106,14 +111,45 @@ function MyPage() {
 
   const handleGenerateInsight = async (groupId: string) => {
     setInsightGroupId(groupId);
-    setInsight('');
+    setInsight(null);
     setInsightLoading(true);
     try {
-      const res = await aiApi.generateInsight(groupId);
-      setInsight(res.data.insight);
+      const res = await aiApi.generateAndSaveInsight(groupId);
+      setInsight(res.data);
+      setGeneratedGroups(prev => new Set(prev).add(groupId));
     } catch {
       alert('AI 요청이 많아 일시적으로 처리할 수 없습니다. 잠시 후 다시 시도해주세요.');
       setInsightGroupId(null);
+    } finally { setInsightLoading(false); }
+  };
+
+  const handleToggleInsight = async (groupId: string) => {
+    // 이미 열려있으면 접기
+    if (insightGroupId === groupId && insight) {
+      setInsightGroupId(null);
+      setInsight(null);
+      return;
+    }
+    // 저장된 인사이트 열기
+    setInsightGroupId(groupId);
+    setInsight(null);
+    setInsightLoading(true);
+    try {
+      const existing = await aiApi.getSavedInsight(groupId);
+      if (existing.data) {
+        setInsight(existing.data);
+      }
+    } catch { /* ignore */ }
+    finally { setInsightLoading(false); }
+  };
+
+  const handleRegenerateInsight = async (groupId: string) => {
+    setInsightLoading(true);
+    try {
+      const res = await aiApi.generateAndSaveInsight(groupId);
+      setInsight(res.data);
+    } catch {
+      alert('AI 요청이 많아 일시적으로 처리할 수 없습니다. 잠시 후 다시 시도해주세요.');
     } finally { setInsightLoading(false); }
   };
 
@@ -215,19 +251,38 @@ function MyPage() {
                           👥 {g.memberCount || g.currentMembers || 0}/{g.maxMembers}명
                           {g.role === 'owner' && <span style={s.ownerBadge}>방장</span>}
                         </div>
-                        <button
-                          onClick={(e) => { e.stopPropagation(); handleGenerateInsight(g.id); }}
-                          style={{ padding: '5px 12px', fontSize: 11, fontWeight: 600, cursor: 'pointer', backgroundColor: '#805ad5', color: '#fff', border: 'none', borderRadius: 6 }}
-                        >🤖 회고</button>
+                        <div style={{ display: 'flex', gap: 4 }}>
+                          {generatedGroups.has(g.id) && (
+                            <button
+                              onClick={(e) => { e.stopPropagation(); handleToggleInsight(g.id); }}
+                              style={{ padding: '5px 10px', fontSize: 11, fontWeight: 600, cursor: 'pointer', backgroundColor: insightGroupId === g.id ? '#e2e8f0' : '#f7fafc', color: '#4a5568', border: '1px solid #e2e8f0', borderRadius: 6 }}
+                            >{insightGroupId === g.id ? '접기' : '열기'}</button>
+                          )}
+                          <button
+                            onClick={(e) => { e.stopPropagation(); handleGenerateInsight(g.id); }}
+                            style={{ padding: '5px 12px', fontSize: 11, fontWeight: 600, cursor: 'pointer', backgroundColor: '#805ad5', color: '#fff', border: 'none', borderRadius: 6 }}
+                          >{generatedGroups.has(g.id) ? '🔄 재생성' : '🤖 회고'}</button>
+                        </div>
                       </div>
                     </div>
                   </div>
                   {insightGroupId === g.id && (
                     <div style={{ padding: '12px 16px', backgroundColor: '#faf5ff', borderRadius: 6, marginBottom: 8 }}>
-                      {insightLoading ? <div style={{ fontSize: 14, color: '#805ad5' }}>🤖 인사이트 생성 중...</div> : <Markdown content={insight} />}
-                      {!insightLoading && insight && (
-                        <button onClick={() => { setInsightGroupId(null); setInsight(''); }} style={{ display: 'block', marginTop: 8, fontSize: 12, color: '#805ad5', background: 'none', border: 'none', cursor: 'pointer' }}>닫기</button>
-                      )}
+                      {insightLoading ? (
+                        <div style={{ fontSize: 14, color: '#805ad5' }}>🤖 인사이트 생성 중...</div>
+                      ) : insight ? (
+                        <div>
+                          <InsightCard insight={insight} />
+                          <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+                            <button
+                              onClick={() => { setInsightGroupId(null); setInsight(null); }}
+                              style={{ fontSize: 12, color: '#718096', background: 'none', border: '1px solid #e2e8f0', borderRadius: 4, padding: '4px 12px', cursor: 'pointer' }}
+                            >
+                              접기
+                            </button>
+                          </div>
+                        </div>
+                      ) : null}
                     </div>
                   )}
                 </div>

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -30,6 +30,7 @@ model User {
   ownedGroups  Group[]      @relation("GroupOwner")
   bans         GroupBan[]
   tokens       DiscussionToken[]
+  insights     DiscussionInsight[]
 
   @@map("users")
 }
@@ -73,6 +74,7 @@ model Group {
   announcements Announcement[]
   bans          GroupBan[]
   schedules     DiscussionSchedule[]
+  insights      DiscussionInsight[]
 
   @@map("groups")
 }
@@ -214,4 +216,24 @@ model DiscussionSchedule {
   group Group @relation(fields: [groupId], references: [id])
 
   @@map("discussion_schedules")
+}
+
+model DiscussionInsight {
+  id              String   @id @default(uuid())
+  groupId         String   @map("group_id")
+  userId          String   @map("user_id")
+  summary         String   @db.Text
+  keywords        String   @db.Text
+  participantStats String  @map("participant_stats") @db.Text
+  memoCount       Int      @default(0) @map("memo_count")
+  discussionCount Int      @default(0) @map("discussion_count")
+  commentCount    Int      @default(0) @map("comment_count")
+  createdAt       DateTime @default(now()) @map("created_at")
+  updatedAt       DateTime @default(now()) @updatedAt @map("updated_at")
+
+  group Group @relation(fields: [groupId], references: [id])
+  user  User  @relation(fields: [userId], references: [id])
+
+  @@unique([groupId, userId])
+  @@map("discussion_insights")
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -12,6 +12,7 @@ import mypageRouter from './routes/mypage.routes';
 import dashboardRouter from './routes/dashboard.routes';
 import aiRouter from './routes/ai.routes';
 import tokenRouter from './routes/token.routes';
+import insightRouter from './routes/insight.routes';
 import { globalErrorHandler } from './middleware/errorHandler';
 
 const app = express();
@@ -52,6 +53,7 @@ app.use('/api/me', mypageRouter);
 app.use('/api', dashboardRouter);
 app.use('/api', aiRouter);
 app.use('/api', tokenRouter);
+app.use('/api', insightRouter);
 
 // 글로벌 에러 핸들러 (모든 라우터 뒤에 등록)
 app.use(globalErrorHandler);

--- a/server/src/routes/insight.routes.ts
+++ b/server/src/routes/insight.routes.ts
@@ -1,0 +1,55 @@
+import { Router, Response } from 'express';
+import { insightService } from '../services/insight.service';
+import { AppError } from '../services/auth.service';
+import { authMiddleware, AuthRequest } from '../middleware/auth.middleware';
+
+const router = Router();
+
+// POST /api/groups/:groupId/insights — 인사이트 생성/재생성
+router.post('/groups/:groupId/insights', authMiddleware, async (req: AuthRequest, res: Response) => {
+  try {
+    const result = await insightService.generate(req.params.groupId as string, req.user!.userId);
+    res.json(result);
+  } catch (err: any) {
+    console.error('[Insight generate error]', err?.message || err);
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: { code: err.code, message: err.message } });
+      return;
+    }
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: '서버 오류가 발생했습니다' } });
+  }
+});
+
+// GET /api/groups/:groupId/insights — 저장된 인사이트 조회
+router.get('/groups/:groupId/insights', authMiddleware, async (req: AuthRequest, res: Response) => {
+  try {
+    const result = await insightService.getByGroup(req.params.groupId as string, req.user!.userId);
+    if (!result) {
+      res.json(null);
+      return;
+    }
+    res.json(result);
+  } catch (err: any) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: { code: err.code, message: err.message } });
+      return;
+    }
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: '서버 오류가 발생했습니다' } });
+  }
+});
+
+// GET /api/me/insights — 내 모든 인사이트
+router.get('/me/insights', authMiddleware, async (req: AuthRequest, res: Response) => {
+  try {
+    const results = await insightService.getMyInsights(req.user!.userId);
+    res.json(results);
+  } catch (err: any) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: { code: err.code, message: err.message } });
+      return;
+    }
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: '서버 오류가 발생했습니다' } });
+  }
+});
+
+export default router;

--- a/server/src/services/ai.service.ts
+++ b/server/src/services/ai.service.ts
@@ -99,20 +99,20 @@ ${memoSummary}
       }
     }
 
-    const systemPrompt = `당신은 독서 토론 정리 도우미입니다. 토론 내용을 핵심 위주로 정리해주세요. 마크다운 형식으로 작성하세요.`;
-    const userPrompt = `다음 토론 스레드를 정리해주세요:
+    const systemPrompt = `당신은 독서 토론 정리 도우미입니다. 스레드에서 나눈 이야기를 핵심 위주로 정리해주세요. 마크다운 형식으로 작성하세요.`;
+    const userPrompt = `다음 스레드 대화를 정리해주세요:
 
 ${thread.join('\n')}
 
 다음 형식으로 정리해주세요:
-## 핵심 논점
-- 주요 논점들
+## 핵심 내용
+- 주요 이야기들
 
 ## 주요 의견
 - 참여자별 핵심 의견
 
 ## 결론 및 인사이트
-- 토론에서 도출된 인사이트`;
+- 대화에서 도출된 인사이트`;
 
     const summary = await callGemini(systemPrompt, userPrompt);
     return { summary };
@@ -156,7 +156,7 @@ ${thread.join('\n')}
       return `- ${d.title} (의견 ${commentCount}개, 댓글 ${replyCount}개)`;
     }).join('\n') || '(토론 없음)';
 
-    const systemPrompt = `당신은 독서 모임 회고 도우미입니다. 사용자의 메모와 모임 토론 내용을 바탕으로 개인화된 독서 인사이트를 정리해주세요. 마크다운 형식으로 작성하세요.`;
+    const systemPrompt = `당신은 독서 모임 회고 도우미입니다. 사용자의 메모와 스레드에서 나눈 이야기를 바탕으로 개인화된 독서 인사이트를 정리해주세요. 마크다운 형식으로 작성하세요.`;
     const userPrompt = `책: ${group.book.title} (${group.book.author || '미상'})
 독서 기간: ${group.readingStartDate.toISOString().slice(0, 10)} ~ ${group.readingEndDate.toISOString().slice(0, 10)}
 참여자: ${group.members.map(m => m.user.nickname).join(', ')}
@@ -164,7 +164,7 @@ ${thread.join('\n')}
 내 메모:
 ${memoText}
 
-모임 토론:
+스레드 대화:
 ${discussionText}
 
 위 내용을 바탕으로 다음을 정리해주세요:
@@ -172,7 +172,7 @@ ${discussionText}
 - 이 책에서 내가 주목한 부분들
 
 ## 💡 핵심 인사이트
-- 메모와 토론에서 얻은 인사이트
+- 메모와 대화에서 얻은 인사이트
 
 ## 🔄 성장 포인트
 - 이 독서를 통해 얻은 것들

--- a/server/src/services/discussion.service.ts
+++ b/server/src/services/discussion.service.ts
@@ -2,6 +2,7 @@ import { PrismaClient } from '@prisma/client';
 import { AppError } from './auth.service';
 import { CreateDiscussionInput, CreateCommentInput } from '../validators';
 import { tokenService } from './token.service';
+import { generateInsightOnThreadClose } from './insight.service';
 
 const prisma = new PrismaClient();
 
@@ -78,14 +79,28 @@ export const discussionService = {
 
   async listTopics(groupId: string, filter?: { authorId?: string; status?: string }) {
     // 종료일 지난 active 스레드를 자동 종료 처리
-    await prisma.discussion.updateMany({
+    const closedThreads = await prisma.discussion.findMany({
       where: {
         groupId,
         status: 'active',
         endDate: { not: null, lt: new Date() },
       },
-      data: { status: 'closed' },
+      select: { id: true },
     });
+
+    if (closedThreads.length > 0) {
+      await prisma.discussion.updateMany({
+        where: {
+          id: { in: closedThreads.map(t => t.id) },
+        },
+        data: { status: 'closed' },
+      });
+
+      // 종료된 스레드에 대해 비동기로 인사이트 생성 (응답 차단 안 함)
+      for (const thread of closedThreads) {
+        generateInsightOnThreadClose(thread.id).catch(() => {});
+      }
+    }
 
     const where: any = { groupId };
     if (filter?.authorId) {
@@ -329,10 +344,17 @@ export const discussionService = {
     newEndDate.setHours(23, 59, 59, 999);
     const newStatus = newEndDate >= new Date() ? 'active' : 'closed';
 
-    return prisma.discussion.update({
+    const updated = await prisma.discussion.update({
       where: { id: discussionId },
       data: { endDate: newEndDate, status: newStatus },
     });
+
+    // 종료로 변경된 경우 인사이트 자동 생성
+    if (newStatus === 'closed') {
+      generateInsightOnThreadClose(discussionId).catch(() => {});
+    }
+
+    return updated;
   },
 
   // 대표 스레드 설정 (방장, 최대 3개)

--- a/server/src/services/group.service.ts
+++ b/server/src/services/group.service.ts
@@ -47,7 +47,6 @@ export const groupService = {
           maxMembers: data.maxMembers,
           readingStartDate: new Date(data.readingStartDate),
           readingEndDate: new Date(data.readingEndDate),
-          discussionDate: null,
           isPrivate: data.isPrivate ?? false,
           password: data.password ?? null,
         },
@@ -314,6 +313,9 @@ export const groupService = {
       if (data.isPrivate === false) {
         // 공개로 전환 시 비밀번호 제거
         updateData.password = null;
+      } else if (data.isPrivate === true && !group.isPrivate && !data.password) {
+        // 공개 → 비공개 전환인데 비밀번호가 없으면 에러
+        throw new AppError(400, 'VALIDATION_ERROR', '비공개 모임은 비밀번호를 설정해야 합니다');
       }
     }
     if (data.password !== undefined && data.password !== null) {

--- a/server/src/services/insight.service.ts
+++ b/server/src/services/insight.service.ts
@@ -1,0 +1,274 @@
+import { PrismaClient } from '@prisma/client';
+import { AppError } from './auth.service';
+import axios from 'axios';
+
+const prisma = new PrismaClient();
+
+const getApiKey = () => process.env.GEMINI_API_KEY || '';
+const getModel = () => process.env.GEMINI_MODEL || 'gemini-2.5-flash';
+
+async function callGemini(systemPrompt: string, userPrompt: string): Promise<string> {
+  const apiKey = getApiKey();
+  if (!apiKey) throw new AppError(500, 'AI_NOT_CONFIGURED', 'Gemini API 키가 설정되지 않았습니다');
+
+  const model = getModel();
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
+
+  const response = await axios.post(url, {
+    system_instruction: { parts: [{ text: systemPrompt }] },
+    contents: [{ parts: [{ text: userPrompt }] }],
+    generationConfig: { temperature: 0.7, maxOutputTokens: 4096 },
+  }, { timeout: 30000 });
+
+  return response.data.candidates?.[0]?.content?.parts?.[0]?.text || '';
+}
+
+export const insightService = {
+  // 인사이트 생성 및 저장
+  async generate(groupId: string, userId: string) {
+    const group = await prisma.group.findUnique({
+      where: { id: groupId },
+      include: {
+        book: true,
+        members: { include: { user: { select: { id: true, nickname: true } } } },
+      },
+    });
+    if (!group) throw new AppError(404, 'NOT_FOUND', '모임을 찾을 수 없습니다');
+
+    // 멤버 확인
+    const isMember = group.members.some(m => m.userId === userId);
+    if (!isMember) throw new AppError(403, 'FORBIDDEN', '모임 참여자만 인사이트를 생성할 수 있습니다');
+
+    // 데이터 수집
+    const [memos, discussions, comments] = await Promise.all([
+      prisma.memo.findMany({
+        where: { groupId, userId },
+        orderBy: { pageStart: 'asc' },
+        select: { content: true, pageStart: true, pageEnd: true },
+      }),
+      prisma.discussion.findMany({
+        where: { groupId },
+        include: {
+          author: { select: { nickname: true } },
+          comments: {
+            include: {
+              author: { select: { id: true, nickname: true } },
+              replies: { include: { author: { select: { id: true, nickname: true } } } },
+            },
+          },
+        },
+      }),
+      prisma.comment.count({ where: { discussion: { groupId }, authorId: userId } }),
+    ]);
+
+    // 참여 통계
+    const myMemoCount = memos.length;
+    const totalDiscussions = discussions.length;
+    const myCommentCount = comments;
+    const participantStats: Record<string, { memos: number; comments: number; replies: number }> = {};
+
+    for (const member of group.members) {
+      participantStats[member.user.nickname] = { memos: 0, comments: 0, replies: 0 };
+    }
+
+    // 각 참여자별 통계 계산
+    const allMemos = await prisma.memo.findMany({
+      where: { groupId },
+      select: { userId: true },
+    });
+    for (const m of allMemos) {
+      const member = group.members.find(mem => mem.userId === m.userId);
+      if (member && participantStats[member.user.nickname]) {
+        participantStats[member.user.nickname].memos++;
+      }
+    }
+    for (const d of discussions) {
+      for (const c of d.comments) {
+        const nick = c.author.nickname;
+        if (participantStats[nick]) participantStats[nick].comments++;
+        for (const r of c.replies) {
+          const rNick = r.author.nickname;
+          if (participantStats[rNick]) participantStats[rNick].replies++;
+        }
+      }
+    }
+
+    // AI 요약 생성
+    const memoText = memos.length > 0
+      ? memos.map(m => `[p.${m.pageStart}-${m.pageEnd}] ${m.content.slice(0, 300)}`).join('\n')
+      : '(작성한 메모 없음)';
+
+    const discussionText = discussions.map(d => {
+      const thread = [`주제: ${d.title}`];
+      for (const c of d.comments.slice(0, 10)) {
+        thread.push(`  ${c.author.nickname}: ${c.content.slice(0, 100)}`);
+      }
+      return thread.join('\n');
+    }).join('\n\n') || '(토론 없음)';
+
+    const systemPrompt = `당신은 독서 모임 인사이트 정리 도우미입니다. 참여자들이 책을 읽고 자유롭게 이야기를 나눈 스레드 내용을 바탕으로 인사이트를 정리해주세요. 반드시 JSON 형식으로만 응답하세요.`;
+    const userPrompt = `책: ${group.book.title} (${group.book.author || '미상'})
+독서 기간: ${group.readingStartDate.toISOString().slice(0, 10)} ~ ${group.readingEndDate.toISOString().slice(0, 10)}
+
+내 메모:
+${memoText}
+
+스레드 대화 내용:
+${discussionText}
+
+다음 JSON 형식으로 응답해주세요:
+{
+  "summary": "전체 활동 및 대화 요약 (3-5문장)",
+  "keywords": ["핵심키워드1", "핵심키워드2", "핵심키워드3", "핵심키워드4", "핵심키워드5"],
+  "highlights": ["인상 깊었던 포인트1", "인상 깊었던 포인트2", "인상 깊었던 포인트3"],
+  "takeaway": "이 독서를 통해 얻은 핵심 한 줄 메시지"
+}`;
+
+    let summary = '';
+    let keywords: string[] = [];
+    let highlights: string[] = [];
+    let takeaway = '';
+
+    try {
+      const raw = await callGemini(systemPrompt, userPrompt);
+      const jsonMatch = raw.match(/\{[\s\S]*\}/);
+      if (jsonMatch) {
+        const parsed = JSON.parse(jsonMatch[0]);
+        summary = parsed.summary || '';
+        keywords = parsed.keywords || [];
+        highlights = parsed.highlights || [];
+        takeaway = parsed.takeaway || '';
+      } else {
+        summary = raw;
+      }
+    } catch (err: any) {
+      console.error('[Insight AI error]', err?.response?.data || err?.message || err);
+      summary = '인사이트 생성에 실패했습니다. 잠시 후 다시 시도해주세요.';
+    }
+
+    // DB에 저장 (upsert)
+    const insight = await prisma.discussionInsight.upsert({
+      where: { groupId_userId: { groupId, userId } },
+      update: {
+        summary: JSON.stringify({ summary, highlights, takeaway }),
+        keywords: JSON.stringify(keywords),
+        participantStats: JSON.stringify(participantStats),
+        memoCount: myMemoCount,
+        discussionCount: totalDiscussions,
+        commentCount: myCommentCount,
+      },
+      create: {
+        groupId,
+        userId,
+        summary: JSON.stringify({ summary, highlights, takeaway }),
+        keywords: JSON.stringify(keywords),
+        participantStats: JSON.stringify(participantStats),
+        memoCount: myMemoCount,
+        discussionCount: totalDiscussions,
+        commentCount: myCommentCount,
+      },
+    });
+
+    return {
+      id: insight.id,
+      groupId: insight.groupId,
+      bookTitle: group.book.title,
+      bookAuthor: group.book.author,
+      summary,
+      keywords,
+      highlights,
+      takeaway,
+      participantStats,
+      memoCount: myMemoCount,
+      discussionCount: totalDiscussions,
+      commentCount: myCommentCount,
+      createdAt: insight.createdAt,
+      updatedAt: insight.updatedAt,
+    };
+  },
+
+  // 저장된 인사이트 조회
+  async getByGroup(groupId: string, userId: string) {
+    const insight = await prisma.discussionInsight.findUnique({
+      where: { groupId_userId: { groupId, userId } },
+      include: {
+        group: { include: { book: { select: { title: true, author: true, coverImageUrl: true } } } },
+      },
+    });
+
+    if (!insight) return null;
+
+    return {
+      id: insight.id,
+      groupId: insight.groupId,
+      bookTitle: insight.group.book.title,
+      bookAuthor: insight.group.book.author,
+      bookCoverUrl: insight.group.book.coverImageUrl,
+      ...JSON.parse(insight.summary),
+      keywords: JSON.parse(insight.keywords),
+      participantStats: JSON.parse(insight.participantStats),
+      memoCount: insight.memoCount,
+      discussionCount: insight.discussionCount,
+      commentCount: insight.commentCount,
+      createdAt: insight.createdAt,
+      updatedAt: insight.updatedAt,
+    };
+  },
+
+  // 내 모든 인사이트 조회
+  async getMyInsights(userId: string) {
+    const insights = await prisma.discussionInsight.findMany({
+      where: { userId },
+      orderBy: { updatedAt: 'desc' },
+      include: {
+        group: { include: { book: { select: { title: true, author: true, coverImageUrl: true } } } },
+      },
+    });
+
+    return insights.map(i => ({
+      id: i.id,
+      groupId: i.groupId,
+      bookTitle: i.group.book.title,
+      bookAuthor: i.group.book.author,
+      bookCoverUrl: i.group.book.coverImageUrl,
+      ...JSON.parse(i.summary),
+      keywords: JSON.parse(i.keywords),
+      memoCount: i.memoCount,
+      discussionCount: i.discussionCount,
+      commentCount: i.commentCount,
+      createdAt: i.createdAt,
+      updatedAt: i.updatedAt,
+    }));
+  },
+};
+
+
+// 스레드 종료 시 자동 인사이트 생성 (모임의 모든 멤버에 대해)
+export async function generateInsightOnThreadClose(discussionId: string) {
+  try {
+    const discussion = await prisma.discussion.findUnique({
+      where: { id: discussionId },
+      include: {
+        group: {
+          include: {
+            members: { select: { userId: true } },
+          },
+        },
+      },
+    });
+
+    if (!discussion) return;
+
+    // 모임의 모든 멤버에 대해 인사이트 생성
+    for (const member of discussion.group.members) {
+      try {
+        await insightService.generate(discussion.groupId, member.userId);
+      } catch {
+        // 개별 멤버 실패해도 계속 진행
+        console.error(`[Insight] 멤버 ${member.userId} 인사이트 생성 실패`);
+      }
+    }
+  } catch (err) {
+    console.error('[Insight] 스레드 종료 인사이트 생성 실패:', err);
+  }
+}

--- a/server/src/validators/index.ts
+++ b/server/src/validators/index.ts
@@ -85,11 +85,7 @@ export const UpdateGroupSchema = z.object({
   readingEndDate: z.string().date().optional(),
   isPrivate: z.boolean().optional(),
   password: z.string().regex(/^\d{6}$/, '비밀번호는 숫자 6자리여야 합니다').optional().nullable(),
-}).refine(data => {
-  // 비공개로 전환할 때 비밀번호 필수
-  if (data.isPrivate === true && !data.password) return false;
-  return true;
-}, { message: '비공개 모임은 비밀번호를 설정해야 합니다' });
+});
 
 // 닉네임 변경
 export const UpdateNicknameSchema = z.object({


### PR DESCRIPTION
## 📝 PR 요약
<!-- 이 PR의 목적과 주요 변경 사항을 간략하게 설명해 주세요. -->
스레드 종료 시 자동 인사이트 생성, 저장, 공유(카카오톡, 디스코드) 기능 
회고 시에도 카드 형식으로 생성, 저장, 공유
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 적어주세요. 이슈를 자동으로 닫으려면 'Resolves #이슈번호' 형태로 작성하세요. -->
- Resolves: #47

## 🏷️ PR 분류
<!-- 해당되는 항목의 [ ] 안에 x를 입력하여 [x]로 만들어 주세요. -->
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ✨ 새로운 기능 추가 (New Feature)
- [ ] 🛠️ 코드 리팩토링 (Refactoring)
- [ ] 📚 문서 수정 (Documentation)
- [ ] ⚙️ 설정/빌드 환경 수정 (Configuration/Build)
- [ ] 🧹 단순 수정 (기능에 영향을 주지 않는 오타 수정, 포맷팅 등)

## 🧪 테스트 방법
<!-- 변경 사항이 정상적으로 동작하는지 확인하기 위해 진행한 테스트 방법과 결과를 설명해 주세요. -->
server 폴더와 client 폴더에서 ```npm run dev``` 실행
종료된 스레드에 들어가서 인사이트 확인
## 📸 스크린샷 또는 GIF (선택 사항)
<!-- UI 변경 사항이나 시각적으로 확인할 수 있는 결과물이 있다면 첨부해 주세요. -->
<img width="304" height="574" alt="image" src="https://github.com/user-attachments/assets/ddf64fab-9372-4372-b79b-931471c64db0" />
