### PR TITLE
fix: 프로필 이미지 업로드 처리 수정

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -15,6 +15,9 @@ apiClient.interceptors.request.use((config) => {
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
+  if (config.data instanceof FormData) {
+    delete config.headers['Content-Type'];
+  }
   return config;
 });
 

--- a/client/src/api/mypage.ts
+++ b/client/src/api/mypage.ts
@@ -26,9 +26,7 @@ export const mypageApi = {
   updateProfileImage: (file: File) => {
     const formData = new FormData();
     formData.append('profileImage', file);
-    return apiClient.patch<User>('/me/profile-image', formData, {
-      headers: { 'Content-Type': 'multipart/form-data' },
-    });
+    return apiClient.patch<User>('/me/profile-image', formData);
   },
 
   changePassword: (currentPassword: string, newPassword: string) =>

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -45,7 +45,9 @@ function SettingsPage() {
       setProfile(res.data);
       setImagePreview((res.data as any).profileImageUrl || '');
       setImageFile(null);
-    } catch { /* ignore */ }
+    } catch (err: any) {
+      showToast(err.response?.data?.error?.message || '프로필 이미지 변경에 실패했습니다');
+    }
     finally { setImageSaving(false); }
   };
 
@@ -138,7 +140,9 @@ function SettingsPage() {
                     const res = await apiClient.patch('/me/profile-image-reset');
                     setProfile(res.data);
                     setImagePreview('');
-                  } catch { /* ignore */ }
+                  } catch (err: any) {
+      showToast(err.response?.data?.error?.message || '프로필 이미지 변경에 실패했습니다');
+    }
                   finally { setImageSaving(false); }
                 }}
                 style={{ padding: '8px 16px', fontSize: 13, fontWeight: 600, color: '#e53e3e', background: '#fff5f5', border: '1px solid #fed7d7', borderRadius: 8, cursor: 'pointer' }}


### PR DESCRIPTION
프로필 이미지가 제 이미지가 제대로 변경되게 하였고,
이전에는 변경에 실패하면 무시가됐는데 '이미지 변경에 실패했습니다.'가 뜨게 했습니다.