### PR TITLE
스레드 일일 생성 제한 구현, KST 시간 계산 수정, 수정/삭제 기능 추가

### DIFF
--- a/client/src/api/discussions.ts
+++ b/client/src/api/discussions.ts
@@ -44,6 +44,12 @@ export const discussionsApi = {
   getRemainingCount: (groupId: string) =>
     apiClient.get<{ used: number; remaining: number; limit: number }>(`/groups/${groupId}/discussions/remaining`),
 
+  updateTopic: (discussionId: string, data: { title: string; content?: string; endDate?: string }) =>
+    apiClient.put(`/discussions/${discussionId}`, data),
+
+  deleteTopic: (discussionId: string) =>
+    apiClient.delete(`/discussions/${discussionId}`),
+
   updateEndDate: (discussionId: string, endDate: string) =>
     apiClient.patch(`/discussions/${discussionId}/end-date`, { endDate }),
 

--- a/client/src/pages/DiscussionsPage.tsx
+++ b/client/src/pages/DiscussionsPage.tsx
@@ -6,6 +6,7 @@ import { aiApi, type AiTopic } from '../api/ai';
 import { useAuthStore } from '../stores/authStore';
 import type { Discussion, Memo, RecommendedTopic, ApiError } from '../types';
 import { AxiosError } from 'axios';
+import { showToast } from '../api/client';
 
 const styles: Record<string, React.CSSProperties> = {
   container: {
@@ -260,6 +261,13 @@ function DiscussionsPage() {
   // 일일 생성 횟수
   const [remainingCount, setRemainingCount] = useState<{ used: number; remaining: number; limit: number } | null>(null);
 
+  // 수정 상태
+  const [editingDiscussion, setEditingDiscussion] = useState<Discussion | null>(null);
+  const [editTitle, setEditTitle] = useState('');
+  const [editContent, setEditContent] = useState('');
+  const [editEndDate, setEditEndDate] = useState('');
+  const [editSaving, setEditSaving] = useState(false);
+
   let currentUserId = user?.id || '';
   if (!currentUserId && accessToken) {
     try {
@@ -309,6 +317,32 @@ function DiscussionsPage() {
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [showCreateModal]);
+
+  // 수정 모달 열릴 때 값 세팅
+  useEffect(() => {
+    if (editingDiscussion) {
+      setEditTitle(editingDiscussion.title);
+      setEditContent((editingDiscussion as any).content || '');
+      setEditEndDate((editingDiscussion as any).endDate ? new Date((editingDiscussion as any).endDate).toISOString().split('T')[0] : '');
+    }
+  }, [editingDiscussion]);
+
+  const handleEditSubmit = async () => {
+    if (!editingDiscussion || !editTitle.trim()) return;
+    setEditSaving(true);
+    try {
+      await discussionsApi.updateTopic(editingDiscussion.id, {
+        title: editTitle.trim(),
+        content: editContent.trim() || undefined,
+        endDate: editEndDate || undefined,
+      });
+      setEditingDiscussion(null);
+      fetchData();
+    } catch (err) {
+      const axiosErr = err as AxiosError<ApiError>;
+      showToast(axiosErr.response?.data?.error?.message || '수정에 실패했습니다');
+    } finally { setEditSaving(false); }
+  };
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -411,7 +445,13 @@ function DiscussionsPage() {
         <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
           <button
             style={styles.createBtn}
-            onClick={() => setShowCreateModal(true)}
+            onClick={() => {
+              if (remainingCount && remainingCount.remaining <= 0) {
+                showToast('오늘 생성 가능한 횟수를 초과했습니다. 내일 다시 시도해 주세요.');
+                return;
+              }
+              setShowCreateModal(true);
+            }}
           >
             + 스레드 만들기
           </button>
@@ -454,19 +494,39 @@ function DiscussionsPage() {
           discussions.filter((d: any) => d.status !== 'closed').map((d) => (
             <div
               key={d.id}
-              style={styles.discussionItem}
-              onClick={() => navigate(`/discussions/${d.id}`)}
-              role="button"
-              tabIndex={0}
-              onKeyDown={(e) => e.key === 'Enter' && navigate(`/discussions/${d.id}`)}
+              style={{ ...styles.discussionItem, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
             >
-              <div style={styles.discussionTitle}>
-                {d.title}
-                {(d as any).endDate && <span style={{ fontSize: 11, color: '#718096', marginLeft: 8 }}>~{new Date((d as any).endDate).toLocaleDateString()}</span>}
+              <div style={{ cursor: 'pointer', flex: 1 }} onClick={() => navigate(`/discussions/${d.id}`)}>
+                <div style={styles.discussionTitle}>
+                  {d.title}
+                  {(d as any).endDate && <span style={{ fontSize: 11, color: '#718096', marginLeft: 8 }}>~{new Date((d as any).endDate).toLocaleDateString()}</span>}
+                </div>
+                <div style={styles.discussionMeta}>
+                  {d.authorNickname} · {new Date(d.createdAt).toLocaleDateString()}
+                </div>
               </div>
-              <div style={styles.discussionMeta}>
-                {d.authorNickname} · {new Date(d.createdAt).toLocaleDateString()}
-              </div>
+              {d.authorId === currentUserId && (
+                <div style={{ display: 'flex', gap: 6, flexShrink: 0 }}>
+                  <button
+                    onClick={(e) => { e.stopPropagation(); setEditingDiscussion(d); }}
+                    style={{ padding: '3px 10px', fontSize: 11, color: '#667eea', background: '#eef2ff', border: '1px solid #c7d2fe', borderRadius: 4, cursor: 'pointer' }}
+                  >수정</button>
+                  <button
+                    onClick={async (e) => {
+                      e.stopPropagation();
+                      if (!confirm('이 스레드를 삭제하시겠습니까?')) return;
+                      try {
+                        await discussionsApi.deleteTopic(d.id);
+                        fetchData();
+                      } catch (err) {
+                        const axiosErr = err as AxiosError<ApiError>;
+                        showToast(axiosErr.response?.data?.error?.message || '삭제에 실패했습니다');
+                      }
+                    }}
+                    style={{ padding: '3px 10px', fontSize: 11, color: '#e53e3e', background: '#fff5f5', border: '1px solid #fed7d7', borderRadius: 4, cursor: 'pointer' }}
+                  >삭제</button>
+                </div>
+              )}
             </div>
           ))
         )}
@@ -632,6 +692,35 @@ function DiscussionsPage() {
                 ))}
               </div>
             )}
+          </div>
+        </div>
+      )}
+
+      {/* 수정 모달 */}
+      {editingDiscussion && (
+        <div style={styles.overlay} onClick={() => setEditingDiscussion(null)}>
+          <div style={styles.modal} onClick={(e) => e.stopPropagation()}>
+            <div style={styles.modalHeader}>
+              <div style={styles.modalTitle}>✏️ 스레드 수정</div>
+              <button style={styles.closeBtn} onClick={() => setEditingDiscussion(null)} aria-label="닫기">×</button>
+            </div>
+            <div style={{ padding: 20 }}>
+              <div style={{ marginBottom: 14 }}>
+                <label style={{ display: 'block', fontSize: 13, fontWeight: 600, marginBottom: 4 }}>제목</label>
+                <input type="text" value={editTitle} onChange={(e) => setEditTitle(e.target.value)} style={styles.input} />
+              </div>
+              <div style={{ marginBottom: 14 }}>
+                <label style={{ display: 'block', fontSize: 13, fontWeight: 600, marginBottom: 4 }}>내용</label>
+                <textarea value={editContent} onChange={(e) => setEditContent(e.target.value)} style={{ ...styles.input, minHeight: 80, resize: 'vertical' as const, fontFamily: 'inherit' }} />
+              </div>
+              <div style={{ marginBottom: 14 }}>
+                <label style={{ display: 'block', fontSize: 13, fontWeight: 600, marginBottom: 4 }}>종료일</label>
+                <input type="date" min={new Date().toISOString().split('T')[0]} value={editEndDate} onChange={(e) => setEditEndDate(e.target.value)} style={styles.input} />
+              </div>
+              <button onClick={handleEditSubmit} disabled={editSaving} style={styles.button}>
+                {editSaving ? '저장 중...' : '수정 완료'}
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/server/src/routes/discussion.routes.ts
+++ b/server/src/routes/discussion.routes.ts
@@ -197,6 +197,39 @@ router.patch('/discussions/:id/end-date', authMiddleware, async (req: AuthReques
   }
 });
 
+// PUT /api/discussions/:id - 스레드 수정 (작성자)
+router.put('/discussions/:id', authMiddleware, async (req: AuthRequest, res: Response) => {
+  try {
+    const { title, content, endDate } = req.body;
+    if (!title || !title.trim()) {
+      res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: '제목을 입력해주세요' } });
+      return;
+    }
+    const result = await discussionService.updateTopic(req.params.id as string, req.user!.userId, { title: title.trim(), content: content?.trim() || null, endDate: endDate || null });
+    res.json(result);
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: { code: err.code, message: err.message } });
+      return;
+    }
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: '서버 오류가 발생했습니다' } });
+  }
+});
+
+// DELETE /api/discussions/:id - 스레드 삭제 (작성자, 댓글 없는 경우만)
+router.delete('/discussions/:id', authMiddleware, async (req: AuthRequest, res: Response) => {
+  try {
+    await discussionService.deleteTopic(req.params.id as string, req.user!.userId);
+    res.json({ message: '스레드가 삭제되었습니다' });
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: { code: err.code, message: err.message } });
+      return;
+    }
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: '서버 오류가 발생했습니다' } });
+  }
+});
+
 // POST /api/discussions/:id/pin - 대표 스레드 설정 (방장)
 router.post('/discussions/:id/pin', authMiddleware, async (req: AuthRequest, res: Response) => {
   try {

--- a/server/src/services/discussion.service.ts
+++ b/server/src/services/discussion.service.ts
@@ -397,13 +397,45 @@ export const discussionService = {
     });
   },
 
+  // 스레드 수정 (작성자)
+  async updateTopic(discussionId: string, userId: string, data: { title: string; content: string | null; endDate: string | null }) {
+    const discussion = await prisma.discussion.findUnique({ where: { id: discussionId } });
+    if (!discussion) throw new AppError(404, 'NOT_FOUND', '스레드를 찾을 수 없습니다');
+    if (discussion.authorId !== userId) throw new AppError(403, 'FORBIDDEN', '작성자만 수정할 수 있습니다');
+
+    const updateData: any = { title: data.title, content: data.content };
+    if (data.endDate) {
+      const endDate = new Date(data.endDate);
+      endDate.setHours(23, 59, 59, 999);
+      updateData.endDate = endDate;
+      updateData.status = endDate >= new Date() ? 'active' : 'closed';
+    }
+
+    return prisma.discussion.update({
+      where: { id: discussionId },
+      data: updateData,
+      include: { author: { select: { id: true, nickname: true } } },
+    });
+  },
+
+  // 스레드 삭제 (작성자, 댓글 없는 경우만)
+  async deleteTopic(discussionId: string, userId: string) {
+    const discussion = await prisma.discussion.findUnique({
+      where: { id: discussionId },
+      include: { _count: { select: { comments: true } } },
+    });
+    if (!discussion) throw new AppError(404, 'NOT_FOUND', '스레드를 찾을 수 없습니다');
+    if (discussion.authorId !== userId) throw new AppError(403, 'FORBIDDEN', '작성자만 삭제할 수 있습니다');
+    if (discussion._count.comments > 0) throw new AppError(409, 'HAS_COMMENTS', '댓글이 있는 스레드는 삭제할 수 없습니다');
+
+    await prisma.discussion.delete({ where: { id: discussionId } });
+  },
+
   // KST 기준 오늘 시작 시각 계산
   _getTodayStartKST(): Date {
+    // 서버가 KST 환경이면 로컬 자정이 곧 KST 자정
     const now = new Date();
-    const kstOffset = 9 * 60 * 60 * 1000;
-    const kstNow = new Date(now.getTime() + kstOffset);
-    const kstToday = new Date(kstNow.getFullYear(), kstNow.getMonth(), kstNow.getDate());
-    return new Date(kstToday.getTime() - kstOffset);
+    return new Date(now.getFullYear(), now.getMonth(), now.getDate());
   },
 
   // 오늘 해당 모임에서 사용자가 생성한 스레드 수


### PR DESCRIPTION
## 📝 PR 요약
<!-- 이 PR의 목적과 주요 변경 사항을 간략하게 설명해 주세요. -->
스레드 일일 생성 횟수 제한 기능 수정 및 스레드 수정/삭제 기능 추가.
- 모임별 하루 3회 생성 제한 (KST 00:00 초기화)
- 횟수 초과 시 토스트로 피드백 표시로 변경
- 작성자 본인 스레드 수정(제목/내용/종료일) 기능
- 댓글 없는 스레드 삭제 기능
- KST 시간 계산 버그 수정 (이중 오프셋 적용 문제)

## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 적어주세요. 이슈를 자동으로 닫으려면 'Resolves #이슈번호' 형태로 작성하세요. -->
- Resolves: #66, #64

## 🏷️ PR 분류
<!-- 해당되는 항목의 [ ] 안에 x를 입력하여 [x]로 만들어 주세요. -->
- [x] 🐛 버그 수정 (Bug Fix)
- [x] ✨ 새로운 기능 추가 (New Feature)
- [ ] 🛠️ 코드 리팩토링 (Refactoring)
- [ ] 📚 문서 수정 (Documentation)
- [ ] ⚙️ 설정/빌드 환경 수정 (Configuration/Build)
- [ ] 🧹 단순 수정 (기능에 영향을 주지 않는 오타 수정, 포맷팅 등)

## 🧪 테스트 방법
<!-- 변경 사항이 정상적으로 동작하는지 확인하기 위해 진행한 테스트 방법과 결과를 설명해 주세요. -->

1. 토론 페이지에서 스레드 3개 생성 → 4번째 시도 시 토스트 메시지 확인
2. 다음 날(KST 00:00 이후) 생성 횟수 초기화 확인
3. 본인 스레드 목록에서 수정 버튼 클릭 → 제목/내용/종료일 수정 확인
4. 댓글 없는 스레드 삭제 → 성공 확인
5. 댓글 있는 스레드 삭제 시도 → "댓글이 있는 스레드는 삭제할 수 없습니다" 에러 확인


## 📸 스크린샷 또는 GIF (선택 사항)
<!-- UI 변경 사항이나 시각적으로 확인할 수 있는 결과물이 있다면 첨부해 주세요. -->
스레드 수정, 삭제 기능 추가 (삭제는 아무런 댓글이 없을때만 가능
<img width="757" height="269" alt="image" src="https://github.com/user-attachments/assets/31023e1d-9fa8-44e5-a640-0df92c00e7b8" />

스레드 생성 횟수 초과 시 토스트 메시지 표시
<img width="799" height="242" alt="image" src="https://github.com/user-attachments/assets/bcf36eb2-015c-41fa-ac1a-8b93169fa74d" />
