### PR TITLE
feat: 스레드 페이지 UX 개선 (#79)

### DIFF
--- a/client/src/api/discussions.ts
+++ b/client/src/api/discussions.ts
@@ -7,7 +7,7 @@ import type {
 } from '../types';
 
 export const discussionsApi = {
-  listByGroup: (groupId: string, params?: { authorId?: string }) =>
+  listByGroup: (groupId: string, params?: { authorId?: string; participantId?: string }) =>
     apiClient.get<Discussion[]>(`/groups/${groupId}/discussions`, { params }),
 
   create: (groupId: string, data: CreateDiscussionRequest) => {

--- a/client/src/components/InsightCard.tsx
+++ b/client/src/components/InsightCard.tsx
@@ -132,7 +132,7 @@ export function InsightCard({ insight }: InsightCardProps) {
         {/* Stats */}
         <div style={{ display: 'flex', gap: 16, fontSize: 12, opacity: 0.6, paddingTop: 12, borderTop: '1px solid rgba(255,255,255,0.1)' }}>
           <span>📝 메모 {insight.memoCount}개</span>
-          <span>💬 토론 {insight.discussionCount}개</span>
+          <span>💬 스레드 {insight.discussionCount}개</span>
           <span>🗨️ 의견 {insight.commentCount}개</span>
         </div>
       </div>

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -327,11 +327,11 @@ function DashboardPage() {
       case 'threads':
         return (
           <div style={styles.section}>
-            <div style={styles.sectionTitle}>📚 책수다 관리</div>
-            <div style={{ fontSize: 13, color: '#718096', marginBottom: 16 }}>스레드 종료일 수정, 대표 수다 설정/해제, 발언권 관리를 합니다.</div>
+            <div style={styles.sectionTitle}>📚 스레드 관리</div>
+            <div style={{ fontSize: 13, color: '#718096', marginBottom: 16 }}>스레드 종료일 수정, 대표 스레드 설정/해제, 발언권 관리를 합니다.</div>
 
             {threads.length === 0 ? (
-              <div style={{ color: '#a0aec0', fontSize: 13 }}>아직 생성된 수다가 없습니다</div>
+              <div style={{ color: '#a0aec0', fontSize: 13 }}>아직 생성된 스레드가 없습니다</div>
             ) : threads.map((d: any) => (
               <div key={d.id} style={{ padding: '12px 0', borderBottom: '1px solid #f0f0f0' }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>

--- a/client/src/pages/DiscussionThreadPage.tsx
+++ b/client/src/pages/DiscussionThreadPage.tsx
@@ -439,7 +439,7 @@ function DiscussionThreadPage() {
       {/* Topic Header */}
       <div style={styles.topicSection}>
         <div style={styles.topicTitle}>
-          {topic?.title || '토론 스레드'}
+          {topic?.title || '스레드'}
           {topic?.isRecommended && <span style={styles.recommendedBadge}>추천</span>}
         </div>
         {topic?.content && <div style={styles.topicContent}>{topic.content}</div>}
@@ -471,7 +471,7 @@ function DiscussionThreadPage() {
           <div style={styles.sectionTitle}>의견 목록</div>
           {comments.length > 0 && (
             <button onClick={handleAiSummary} disabled={aiLoading} style={styles.aiButton}>
-              {aiLoading ? '정리 중...' : '🤖 토론 정리'}
+              {aiLoading ? '정리 중...' : '🤖 스레드 정리'}
             </button>
           )}
         </div>

--- a/client/src/pages/DiscussionsPage.tsx
+++ b/client/src/pages/DiscussionsPage.tsx
@@ -276,8 +276,14 @@ function DiscussionsPage() {
   const [myMemos, setMyMemos] = useState<Memo[]>([]);
   const [groupInfo, setGroupInfo] = useState<GroupDetail | null>(null);
   const [loading, setLoading] = useState(true);
-  const [filterMine, setFilterMine] = useState(false);
+  const [filterMode, setFilterMode] = useState<'all' | 'authored' | 'participated'>('all');
   const [showCreateModal, setShowCreateModal] = useState(false);
+  const [threadTab, setThreadTab] = useState<'active' | 'closed'>('active');
+  const [sortBy, setSortBy] = useState<'newest' | 'oldest' | 'popular'>('newest');
+  const [closedSortBy, setClosedSortBy] = useState<'newest' | 'oldest' | 'popular'>('popular');
+  const [activePage, setActivePage] = useState(1);
+  const [closedPage, setClosedPage] = useState(1);
+  const PAGE_SIZE = 5;
 
   // Form state
   const [formTitle, setFormTitle] = useState('');
@@ -316,7 +322,9 @@ function DiscussionsPage() {
     if (!groupId) return;
     setLoading(true);
     try {
-      const params = filterMine && currentUserId ? { authorId: currentUserId } : undefined;
+      const params: any = {};
+      if (filterMode === 'authored' && currentUserId) params.authorId = currentUserId;
+      if (filterMode === 'participated' && currentUserId) params.participantId = currentUserId;
       const [discRes, recRes, memoRes, groupRes] = await Promise.all([
         discussionsApi.listByGroup(groupId!, params),
         discussionsApi.getRecommendations(groupId!).catch(() => ({ data: [] as RecommendedTopic[] })),
@@ -342,7 +350,7 @@ function DiscussionsPage() {
 
   useEffect(() => {
     fetchData();
-  }, [groupId, filterMine]);
+  }, [groupId, filterMode]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -512,16 +520,22 @@ function DiscussionsPage() {
       <div style={styles.headerRow}>
         <div style={styles.filterRow}>
           <button
-            style={{ ...styles.filterBtn, ...(!filterMine ? styles.filterBtnActive : {}) }}
-            onClick={() => setFilterMine(false)}
+            style={{ ...styles.filterBtn, ...(filterMode === 'all' ? styles.filterBtnActive : {}) }}
+            onClick={() => setFilterMode('all')}
           >
             전체
           </button>
           <button
-            style={{ ...styles.filterBtn, ...(filterMine ? styles.filterBtnActive : {}) }}
-            onClick={() => setFilterMine(true)}
+            style={{ ...styles.filterBtn, ...(filterMode === 'authored' ? styles.filterBtnActive : {}) }}
+            onClick={() => setFilterMode('authored')}
           >
             내 작성
+          </button>
+          <button
+            style={{ ...styles.filterBtn, ...(filterMode === 'participated' ? styles.filterBtnActive : {}) }}
+            onClick={() => setFilterMode('participated')}
+          >
+            내 참여
           </button>
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
@@ -545,8 +559,8 @@ function DiscussionsPage() {
         </div>
       </div>
 
-      {/* 📌 대표 스레드 (고정) */}
-      {!loading && discussions.filter((d: any) => d.isPinned).length > 0 && (
+      {/* 📌 대표 스레드 (고정) — 전체 필터에서만 표시 */}
+      {filterMode === 'all' && !loading && discussions.filter((d: any) => d.isPinned).length > 0 && (
         <div style={{ ...styles.section, borderLeft: '4px solid #3182ce' }}>
           <div style={styles.sectionTitle}>📌 대표 스레드</div>
           {discussions.filter((d: any) => d.isPinned).map((d) => (
@@ -562,6 +576,11 @@ function DiscussionsPage() {
                 {d.title}
                 {(d as any).status === 'closed' && <span style={{ fontSize: 11, backgroundColor: '#fed7d7', color: '#c53030', padding: '2px 8px', borderRadius: 12, marginLeft: 8 }}>종료</span>}
               </div>
+              {d.content && (
+                <div style={{ fontSize: 13, color: '#4a5568', marginTop: 4, lineHeight: 1.5, display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
+                  {d.content}
+                </div>
+              )}
               <div style={styles.discussionMeta}>
                 {d.authorNickname} · {(d as any).endDate && `~${new Date((d as any).endDate).toLocaleDateString()}`}
               </div>
@@ -570,83 +589,116 @@ function DiscussionsPage() {
         </div>
       )}
 
-      {/* 🟢 진행중인 스레드 */}
+      {/* 스레드 탭 (진행중 / 종료) */}
       <div style={styles.section}>
-        <div style={styles.sectionTitle}>🟢 진행중인 스레드</div>
-        {loading ? (
-          <div style={styles.emptyState}>불러오는 중...</div>
-        ) : discussions.filter((d: any) => d.status !== 'closed').length === 0 ? (
-          <div style={styles.emptyState}>진행중인 스레드가 없습니다</div>
-        ) : (
-          discussions.filter((d: any) => d.status !== 'closed').map((d) => (
-            <div
-              key={d.id}
-              style={{ ...styles.discussionItem, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
-            >
-              <div style={{ cursor: 'pointer', flex: 1 }} onClick={() => navigate(`/discussions/${d.id}`)}>
-                <div style={styles.discussionTitle}>
-                  {d.title}
-                  {(d as any).endDate && <span style={{ fontSize: 11, color: '#718096', marginLeft: 8 }}>~{new Date((d as any).endDate).toLocaleDateString()}</span>}
+        {filterMode !== 'all' && (
+          <div style={{ fontSize: 12, color: '#718096', marginBottom: 12 }}>
+            {filterMode === 'authored' ? '📝 내가 작성한 스레드만 표시됩니다' : '💬 내가 의견이나 댓글을 남긴 스레드가 표시됩니다'}
+          </div>
+        )}
+        <div style={{ display: 'flex', gap: 0, borderBottom: '2px solid #e2e8f0', marginBottom: 16 }}>
+          <button
+            style={{ padding: '8px 16px', fontSize: 14, fontWeight: threadTab === 'active' ? 600 : 400, cursor: 'pointer', border: 'none', background: 'none', color: threadTab === 'active' ? '#3182ce' : '#718096', borderBottom: threadTab === 'active' ? '2px solid #3182ce' : '2px solid transparent', marginBottom: -2 }}
+            onClick={() => { setThreadTab('active'); setActivePage(1); }}
+          >🟢 진행중</button>
+          <button
+            style={{ padding: '8px 16px', fontSize: 14, fontWeight: threadTab === 'closed' ? 600 : 400, cursor: 'pointer', border: 'none', background: 'none', color: threadTab === 'closed' ? '#e53e3e' : '#718096', borderBottom: threadTab === 'closed' ? '2px solid #e53e3e' : '2px solid transparent', marginBottom: -2 }}
+            onClick={() => { setThreadTab('closed'); setClosedPage(1); }}
+          >🔴 종료</button>
+        </div>
+
+        {/* 정렬 */}
+        <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 12 }}>
+          <select
+            style={{ padding: '4px 10px', fontSize: 12, border: '1px solid #ddd', borderRadius: 4 }}
+            value={threadTab === 'active' ? sortBy : closedSortBy}
+            onChange={e => {
+              const v = e.target.value as 'newest' | 'oldest' | 'popular';
+              if (threadTab === 'active') { setSortBy(v); setActivePage(1); }
+              else { setClosedSortBy(v); setClosedPage(1); }
+            }}
+          >
+            <option value="newest">최신순</option>
+            <option value="oldest">오래된순</option>
+            <option value="popular">답글 많은순</option>
+          </select>
+        </div>
+
+        {(() => {
+          const isActive = threadTab === 'active';
+          const filtered = discussions.filter((d: any) => isActive ? d.status !== 'closed' : d.status === 'closed');
+          const currentSort = isActive ? sortBy : closedSortBy;
+          const sorted = [...filtered].sort((a: any, b: any) => {
+            if (currentSort === 'newest') return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+            if (currentSort === 'oldest') return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+            return (b.commentCount || 0) - (a.commentCount || 0);
+          });
+          const currentPage = isActive ? activePage : closedPage;
+          const totalPages = Math.ceil(sorted.length / PAGE_SIZE);
+          const paged = sorted.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+
+          if (loading) return <div style={styles.emptyState}>불러오는 중...</div>;
+          if (sorted.length === 0) return <div style={styles.emptyState}>{isActive ? '진행중인 스레드가 없습니다' : '종료된 스레드가 없습니다'}</div>;
+
+          return (
+            <>
+              {paged.map((d: any) => (
+                <div
+                  key={d.id}
+                  style={{ ...styles.discussionItem, display: 'flex', justifyContent: 'space-between', alignItems: 'center', ...(threadTab === 'closed' ? { opacity: 0.7 } : {}) }}
+                >
+                  <div style={{ cursor: 'pointer', flex: 1 }} onClick={() => navigate(`/discussions/${d.id}`)}>
+                    <div style={styles.discussionTitle}>
+                      {d.title}
+                      {d.endDate && <span style={{ fontSize: 11, color: '#718096', marginLeft: 8 }}>~{new Date(d.endDate).toLocaleDateString()}</span>}
+                      {d.status === 'closed' && <span style={{ fontSize: 11, backgroundColor: '#fed7d7', color: '#c53030', padding: '2px 8px', borderRadius: 12, marginLeft: 8 }}>종료</span>}
+                      {d.commentCount > 0 && <span style={{ fontSize: 11, color: '#a0aec0', marginLeft: 8 }}>💬 {d.commentCount}</span>}
+                    </div>
+                    <div style={styles.discussionMeta}>
+                      {d.authorNickname} · {new Date(d.createdAt).toLocaleDateString()}
+                    </div>
+                  </div>
+                  {isActive && d.authorId === currentUserId && !isReadOnly && (
+                    <div style={{ display: 'flex', gap: 6, flexShrink: 0 }}>
+                      <button
+                        onClick={(e) => { e.stopPropagation(); setEditingDiscussion(d); }}
+                        style={{ padding: '3px 10px', fontSize: 11, color: '#667eea', background: '#eef2ff', border: '1px solid #c7d2fe', borderRadius: 4, cursor: 'pointer' }}
+                      >수정</button>
+                      <button
+                        onClick={async (e) => {
+                          e.stopPropagation();
+                          if (!confirm('이 스레드를 삭제하시겠습니까?')) return;
+                          try {
+                            await discussionsApi.deleteTopic(d.id);
+                            fetchData();
+                          } catch (err) {
+                            const axiosErr = err as AxiosError<ApiError>;
+                            showToast(axiosErr.response?.data?.error?.message || '삭제에 실패했습니다');
+                          }
+                        }}
+                        style={{ padding: '3px 10px', fontSize: 11, color: '#e53e3e', background: '#fff5f5', border: '1px solid #fed7d7', borderRadius: 4, cursor: 'pointer' }}
+                      >삭제</button>
+                    </div>
+                  )}
                 </div>
-                <div style={styles.discussionMeta}>
-                  {d.authorNickname} · {new Date(d.createdAt).toLocaleDateString()}
-                </div>
-              </div>
-              {d.authorId === currentUserId && !isReadOnly && (
-                <div style={{ display: 'flex', gap: 6, flexShrink: 0 }}>
-                  <button
-                    onClick={(e) => { e.stopPropagation(); setEditingDiscussion(d); }}
-                    style={{ padding: '3px 10px', fontSize: 11, color: '#667eea', background: '#eef2ff', border: '1px solid #c7d2fe', borderRadius: 4, cursor: 'pointer' }}
-                  >수정</button>
-                  <button
-                    onClick={async (e) => {
-                      e.stopPropagation();
-                      if (isReadOnly) {
-                        showToast(readOnlyMessage || '독서기간 중에만 삭제할 수 있습니다');
-                        return;
-                      }
-                      if (!confirm('이 스레드를 삭제하시겠습니까?')) return;
-                      try {
-                        await discussionsApi.deleteTopic(d.id);
-                        fetchData();
-                      } catch (err) {
-                        const axiosErr = err as AxiosError<ApiError>;
-                        showToast(axiosErr.response?.data?.error?.message || '삭제에 실패했습니다');
-                      }
-                    }}
-                    style={{ padding: '3px 10px', fontSize: 11, color: '#e53e3e', background: '#fff5f5', border: '1px solid #fed7d7', borderRadius: 4, cursor: 'pointer' }}
-                  >삭제</button>
+              ))}
+
+              {/* 페이지네이션 */}
+              {totalPages > 1 && (
+                <div style={{ display: 'flex', justifyContent: 'center', gap: 8, marginTop: 16 }}>
+                  {Array.from({ length: totalPages }, (_, i) => i + 1).map(p => (
+                    <button
+                      key={p}
+                      style={{ padding: '4px 10px', fontSize: 12, border: '1px solid #ddd', borderRadius: 4, backgroundColor: p === currentPage ? '#3182ce' : '#fff', color: p === currentPage ? '#fff' : '#333', cursor: 'pointer' }}
+                      onClick={() => isActive ? setActivePage(p) : setClosedPage(p)}
+                    >{p}</button>
+                  ))}
                 </div>
               )}
-            </div>
-          ))
-        )}
+            </>
+          );
+        })()}
       </div>
-
-      {/* 🔴 종료된 스레드 */}
-      {!loading && discussions.filter((d: any) => d.status === 'closed').length > 0 && (
-        <div style={styles.section}>
-          <div style={styles.sectionTitle}>🔴 종료된 스레드</div>
-          {discussions.filter((d: any) => d.status === 'closed').map((d) => (
-            <div
-              key={d.id}
-              style={{ ...styles.discussionItem, opacity: 0.6 }}
-              onClick={() => navigate(`/discussions/${d.id}`)}
-              role="button"
-              tabIndex={0}
-              onKeyDown={(e) => e.key === 'Enter' && navigate(`/discussions/${d.id}`)}
-            >
-              <div style={styles.discussionTitle}>
-                {d.title}
-                <span style={{ fontSize: 11, backgroundColor: '#fed7d7', color: '#c53030', padding: '2px 8px', borderRadius: 12, marginLeft: 8 }}>종료</span>
-              </div>
-              <div style={styles.discussionMeta}>
-                {d.authorNickname} · {new Date(d.createdAt).toLocaleDateString()}
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
 
       {/* 스레드 만들기 모달 */}
       {showCreateModal && (

--- a/client/src/pages/GroupDetailPage.tsx
+++ b/client/src/pages/GroupDetailPage.tsx
@@ -579,7 +579,7 @@ function GroupDetailPage() {
       {/* Recent Discussions */}
       {group.recentDiscussions && group.recentDiscussions.length > 0 && (
         <div style={styles.section}>
-          <div style={styles.sectionTitle}>💬 최근 토론</div>
+          <div style={styles.sectionTitle}>💬 최근 스레드</div>
           {group.recentDiscussions.map((d) => (
             <Link key={d.id} to={`/discussions/${d.id}`} style={{ textDecoration: 'none' }}>
               <div style={styles.summaryItem}>

--- a/client/src/pages/MyPage.tsx
+++ b/client/src/pages/MyPage.tsx
@@ -278,10 +278,10 @@ function MyPage() {
         </div>
       )}
 
-      {/* 참여 토론 */}
+      {/* 참여 스레드 */}
       {discussions.length > 0 && (
         <div style={{ ...s.section, marginTop: 16 }}>
-          <div style={s.sectionTitle}>💬 참여 토론 ({discussions.length})</div>
+          <div style={s.sectionTitle}>💬 참여 스레드 ({discussions.length})</div>
           {discussions.map((d) => (
             <div key={d.id} style={s.listItem} onClick={() => navigate(`/discussions/${d.id}`)} role="button" tabIndex={0} onKeyDown={(e) => e.key === 'Enter' && navigate(`/discussions/${d.id}`)}>
               <div style={s.listItemTitle}>

--- a/server/src/routes/discussion.routes.ts
+++ b/server/src/routes/discussion.routes.ts
@@ -39,9 +39,10 @@ router.get('/groups/:groupId/discussions', authMiddleware, async (req: AuthReque
   try {
     const authorId = typeof req.query.authorId === 'string' ? req.query.authorId : undefined;
     const status = typeof req.query.status === 'string' ? req.query.status : undefined;
+    const participantId = typeof req.query.participantId === 'string' ? req.query.participantId : undefined;
     const discussions = await discussionService.listTopics(
       req.params.groupId as string,
-      { ...(authorId && { authorId }), ...(status && { status }) },
+      { ...(authorId && { authorId }), ...(status && { status }), ...(participantId && { participantId }) },
     );
     res.json(discussions);
   } catch (err) {

--- a/server/src/services/discussion.service.ts
+++ b/server/src/services/discussion.service.ts
@@ -81,7 +81,7 @@ export const discussionService = {
     };
   },
 
-  async listTopics(groupId: string, filter?: { authorId?: string; status?: string }) {
+  async listTopics(groupId: string, filter?: { authorId?: string; status?: string; participantId?: string }) {
     // 종료일 지난 active 스레드를 자동 종료 처리
     const closedThreads = await prisma.discussion.findMany({
       where: {
@@ -112,6 +112,14 @@ export const discussionService = {
     }
     if (filter?.status) {
       where.status = filter.status;
+    }
+    if (filter?.participantId) {
+      // 내가 작성했거나, 내가 의견/댓글을 남긴 스레드
+      where.OR = [
+        { authorId: filter.participantId },
+        { comments: { some: { authorId: filter.participantId } } },
+        { comments: { some: { replies: { some: { authorId: filter.participantId } } } } },
+      ];
     }
 
     const discussions = await prisma.discussion.findMany({


### PR DESCRIPTION
## 📝 PR 요약

스레드 페이지 UX를 개선하고, "토론" 명칭을 "스레드"로 전체 통일합니다.

- 진행중/종료 스레드를 탭으로 분리
- 페이지네이션 (5개씩)
- 정렬 토글 (최신순/오래된순/답글 많은순, 종료 탭 기본값: 답글 많은순)
- 필터 확장: 전체 / 내 작성 / 내 참여 (설명 텍스트 포함)
- 대표 스레드 내용 미리보기 (2줄)
- 내 작성/내 참여 필터 시 대표 스레드 숨김
- "토론" → "스레드" 명칭 전체 통일

## 🔗 관련 이슈

- Resolves: #79

## 🏷️ PR 분류

- [x] ✨ 새로운 기능 추가 (New Feature)

## 🧪 테스트 방법

1. 스레드 페이지 접속 → 진행중/종료 탭 전환 확인
2. 정렬 드롭다운 변경 → 목록 순서 변경 확인
3. 스레드 6개 이상 생성 → 페이지네이션 버튼 표시 확인
4. "내 작성" 클릭 → 내가 작성한 스레드만 표시, 설명 텍스트 확인
5. "내 참여" 클릭 → 의견/댓글 남긴 스레드 표시, 설명 텍스트 확인
6. 내 작성/내 참여 시 대표 스레드 섹션 숨김 확인
7. 대표 스레드에 내용 2줄 미리보기 확인
8. 모임 상세 "최근 스레드", 마이페이지 "참여 스레드" 등 명칭 변경 확인
