### PR TITLE
feat: 모임장 대시보드 UX 개선 (#81) 

### DIFF
--- a/client/src/api/discussions.ts
+++ b/client/src/api/discussions.ts
@@ -91,4 +91,7 @@ export const discussionsApi = {
 
   grantTokens: (discussionId: string, userId: string, amount: number) =>
     apiClient.post(`/discussions/${discussionId}/tokens/grant`, { userId, amount }),
+
+  getRequestedThreads: (groupId: string) =>
+    apiClient.get<any[]>(`/groups/${groupId}/tokens/requested-threads`),
 };

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -7,11 +7,10 @@ import { useAuthStore } from '../stores/authStore';
 import type { GroupDetail, Discussion } from '../types';
 
 const tabs = [
-  { id: 'calendar', label: '📅 모임 일정' },
-  { id: 'invite', label: '🔗 초대 링크' },
+  { id: 'threads', label: '📚 스레드 관리' },
   { id: 'announcements', label: '📢 공지사항' },
   { id: 'members', label: '👥 멤버 관리' },
-  { id: 'threads', label: '📚 스레드 관리' },
+  { id: 'invite', label: '🔗 초대 링크' },
 ] as const;
 
 type TabId = typeof tabs[number]['id'];
@@ -42,7 +41,7 @@ function DashboardPage() {
   const { id: groupId } = useParams<{ id: string }>();
   const user = useAuthStore((s) => s.user);
   const accessToken = useAuthStore((s) => s.accessToken);
-  const [activeTab, setActiveTab] = useState<TabId>('calendar');
+  const [activeTab, setActiveTab] = useState<TabId>('threads');
 
   const [group, setGroup] = useState<GroupDetail | null>(null);
   const [inviteCode, setInviteCode] = useState<string | null>(null);
@@ -54,6 +53,12 @@ function DashboardPage() {
   const [editingEndDateValue, setEditingEndDateValue] = useState('');
   const [tokenRequestsForId, setTokenRequestsForId] = useState<string | null>(null);
   const [tokenRequests, setTokenRequests] = useState<any[]>([]);
+  const [threadMgmtTab, setThreadMgmtTab] = useState<'active' | 'closed' | 'tokenRequests'>('active');
+  const [threadMgmtSort, setThreadMgmtSort] = useState<'newest' | 'oldest' | 'popular'>('newest');
+  const [threadMgmtClosedSort, setThreadMgmtClosedSort] = useState<'newest' | 'oldest' | 'popular'>('popular');
+  const [threadMgmtPage, setThreadMgmtPage] = useState(1);
+  const [requestedThreads, setRequestedThreads] = useState<any[]>([]);
+  const MGMT_PAGE_SIZE = 5;
   const [newAnnTitle, setNewAnnTitle] = useState('');
   const [newAnnContent, setNewAnnContent] = useState('');
   const [newSchedTitle, setNewSchedTitle] = useState('');
@@ -83,6 +88,12 @@ function DashboardPage() {
       setAnnouncements(annRes.data);
       setSchedules(schedRes.data);
       setThreads(threadsRes.data);
+
+      // 발언권 요청 스레드 조회
+      if (groupId) {
+        const reqThreadsRes = await discussionsApi.getRequestedThreads(groupId).catch(() => ({ data: [] }));
+        setRequestedThreads(reqThreadsRes.data);
+      }
     } catch {}
   };
 
@@ -103,9 +114,23 @@ function DashboardPage() {
     setTimeout(() => setCopied(false), 2000);
   };
 
+  const [kickTarget, setKickTarget] = useState<{ userId: string; nickname: string } | null>(null);
+  const [kickInput, setKickInput] = useState('');
+
   const handleRemoveMember = async (userId: string, nickname: string) => {
-    if (!groupId || !confirm(`${nickname}님을 모임에서 삭제하시겠습니까?`)) return;
-    await dashboardApi.removeMember(groupId, userId);
+    setKickTarget({ userId, nickname });
+    setKickInput('');
+  };
+
+  const confirmKick = async () => {
+    if (!groupId || !kickTarget) return;
+    if (kickInput !== '강제 퇴장') {
+      alert('입력이 일치하지 않습니다.');
+      return;
+    }
+    await dashboardApi.removeMember(groupId, kickTarget.userId);
+    setKickTarget(null);
+    setKickInput('');
     fetchAll();
   };
 
@@ -149,12 +174,14 @@ function DashboardPage() {
     }
   };
 
+  const [alertMessage, setAlertMessage] = useState<string | null>(null);
+
   const handlePinThread = async (discussionId: string) => {
     try {
       await discussionsApi.pinThread(discussionId);
       fetchAll();
     } catch (err: any) {
-      alert(err.response?.data?.error?.message || '대표 설정에 실패했습니다');
+      setAlertMessage(err.response?.data?.error?.message || '대표 설정에 실패했습니다');
     }
   };
 
@@ -224,51 +251,11 @@ function DashboardPage() {
 
   const renderTabContent = () => {
     switch (activeTab) {
-      case 'calendar':
-        return (
-          <div style={styles.section}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
-              <div style={styles.sectionTitle}>📅 모임 일정</div>
-              <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-                <button style={{ ...styles.btn, ...styles.btnSecondary }} onClick={() => setCalMonth(new Date(calMonth.getFullYear(), calMonth.getMonth() - 1))}>◀</button>
-                <span style={{ fontSize: 14, fontWeight: 600 }}>{calMonth.getFullYear()}년 {calMonth.getMonth() + 1}월</span>
-                <button style={{ ...styles.btn, ...styles.btnSecondary }} onClick={() => setCalMonth(new Date(calMonth.getFullYear(), calMonth.getMonth() + 1))}>▶</button>
-              </div>
-            </div>
-            <div style={styles.calGrid}>
-              {['일','월','화','수','목','금','토'].map(d => <div key={d} style={{ ...styles.calCell, fontWeight: 600, fontSize: 11, color: '#718096' }}>{d}</div>)}
-              {renderCalendar()}
-            </div>
-            <div style={{ marginTop: 12, fontSize: 12, color: '#718096' }}>
-              <span style={{ display: 'inline-block', width: 12, height: 12, backgroundColor: '#ebf8ff', borderRadius: 2, marginRight: 4, verticalAlign: 'middle' }} /> 독서 기간
-            </div>
-            <div style={{ marginTop: 16, padding: '12px 0', borderTop: '1px solid #f0f0f0' }}>
-              <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 8 }}>일정 추가</div>
-              <input style={styles.input} placeholder="일정 제목" value={newSchedTitle} onChange={e => setNewSchedTitle(e.target.value)} />
-              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
-                <input type="date" style={styles.input} value={newSchedStart} onChange={e => setNewSchedStart(e.target.value)} />
-                <input type="date" style={styles.input} value={newSchedEnd} onChange={e => setNewSchedEnd(e.target.value)} />
-              </div>
-              <button style={{ ...styles.btn, ...styles.btnPrimary }} onClick={handleCreateSchedule}>일정 추가</button>
-            </div>
-            {schedules.length > 0 && (
-              <div style={{ marginTop: 12 }}>
-                <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 8 }}>등록된 일정</div>
-                {schedules.map(s => (
-                  <div key={s.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '6px 0', borderBottom: '1px solid #f0f0f0', fontSize: 13 }}>
-                    <span><strong>{s.title}</strong> ({new Date(s.startDate).toLocaleDateString()} ~ {new Date(s.endDate).toLocaleDateString()})</span>
-                    <button style={{ ...styles.btn, ...styles.btnDanger, padding: '2px 8px', fontSize: 11 }} onClick={() => handleDeleteSchedule(s.id)}>삭제</button>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-        );
-
       case 'invite':
         return (
           <div style={styles.section}>
             <div style={styles.sectionTitle}>🔗 초대 링크</div>
+            <div style={{ fontSize: 13, color: '#718096', marginBottom: 16 }}>초대 링크를 생성하여 새 멤버를 모임에 초대합니다. 링크는 생성 후 30분간 유효합니다.</div>
             {inviteCode ? (
               <div>
                 <div style={styles.inviteBox}>
@@ -278,7 +265,7 @@ function DashboardPage() {
                 </div>
                 {inviteExpiresAt && (
                   <div style={{ fontSize: 12, color: '#718096', marginTop: 8 }}>
-                    ⏰ 만료: {new Date(inviteExpiresAt).toLocaleString()} (생성 후 30분)
+                    ⏰ 만료: {new Date(inviteExpiresAt).toLocaleString()}
                   </div>
                 )}
               </div>
@@ -292,6 +279,7 @@ function DashboardPage() {
         return (
           <div style={styles.section}>
             <div style={styles.sectionTitle}>📢 공지사항</div>
+            <div style={{ fontSize: 13, color: '#718096', marginBottom: 16 }}>모임 참여자 전체에게 보이는 공지를 작성합니다.</div>
             <input style={styles.input} placeholder="제목" value={newAnnTitle} onChange={e => setNewAnnTitle(e.target.value)} />
             <textarea style={styles.textarea} placeholder="내용" value={newAnnContent} onChange={e => setNewAnnContent(e.target.value)} />
             <button style={{ ...styles.btn, ...styles.btnPrimary }} onClick={handleCreateAnnouncement}>공지 작성</button>
@@ -314,10 +302,11 @@ function DashboardPage() {
         return (
           <div style={styles.section}>
             <div style={styles.sectionTitle}>👥 멤버 관리</div>
+            <div style={{ fontSize: 13, color: '#718096', marginBottom: 16 }}>부적절한 멤버를 강제 퇴장시킬 수 있습니다. 퇴장된 멤버는 재참여가 불가능합니다.</div>
             {group.members.filter(m => m.role !== 'owner').map(m => (
               <div key={m.id} style={styles.memberItem}>
                 <span>{m.nickname}</span>
-                <button style={{ ...styles.btn, ...styles.btnDanger, padding: '4px 10px', fontSize: 11 }} onClick={() => handleRemoveMember(m.userId, m.nickname)}>삭제</button>
+                <button style={{ ...styles.btn, ...styles.btnDanger, padding: '4px 10px', fontSize: 11 }} onClick={() => handleRemoveMember(m.userId, m.nickname)}>강퇴</button>
               </div>
             ))}
             {group.members.filter(m => m.role !== 'owner').length === 0 && <div style={{ color: '#a0aec0', fontSize: 13 }}>멤버가 없습니다</div>}
@@ -325,59 +314,131 @@ function DashboardPage() {
         );
 
       case 'threads':
+        const currentMgmtSort = threadMgmtTab === 'active' ? threadMgmtSort : threadMgmtClosedSort;
+        const mgmtFiltered = threads.filter((d: any) => threadMgmtTab === 'active' ? d.status !== 'closed' : d.status === 'closed');
+        const mgmtSorted = [...mgmtFiltered].sort((a: any, b: any) => {
+          if (currentMgmtSort === 'newest') return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+          if (currentMgmtSort === 'oldest') return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+          return (b.commentCount || 0) - (a.commentCount || 0);
+        });
+        const mgmtTotalPages = Math.ceil(mgmtSorted.length / MGMT_PAGE_SIZE);
+        const mgmtPaged = mgmtSorted.slice((threadMgmtPage - 1) * MGMT_PAGE_SIZE, threadMgmtPage * MGMT_PAGE_SIZE);
+
         return (
           <div style={styles.section}>
             <div style={styles.sectionTitle}>📚 스레드 관리</div>
             <div style={{ fontSize: 13, color: '#718096', marginBottom: 16 }}>스레드 종료일 수정, 대표 스레드 설정/해제, 발언권 관리를 합니다.</div>
 
-            {threads.length === 0 ? (
-              <div style={{ color: '#a0aec0', fontSize: 13 }}>아직 생성된 스레드가 없습니다</div>
-            ) : threads.map((d: any) => (
-              <div key={d.id} style={{ padding: '12px 0', borderBottom: '1px solid #f0f0f0' }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                  <div style={{ flex: 1 }}>
-                    <div style={{ fontSize: 14, fontWeight: 500, color: '#2d3748' }}>
-                      {d.title}
-                      {d.isPinned && <span style={{ fontSize: 11, backgroundColor: '#ebf8ff', color: '#3182ce', padding: '2px 6px', borderRadius: 10, marginLeft: 6 }}>대표</span>}
-                      {d.status === 'closed' && <span style={{ fontSize: 11, backgroundColor: '#fed7d7', color: '#c53030', padding: '2px 6px', borderRadius: 10, marginLeft: 6 }}>종료</span>}
+            {/* 진행중/종료/발언권 요청 탭 */}
+            <div style={{ display: 'flex', gap: 0, borderBottom: '2px solid #e2e8f0', marginBottom: 12 }}>
+              <button
+                style={{ padding: '8px 16px', fontSize: 13, fontWeight: threadMgmtTab === 'active' ? 600 : 400, cursor: 'pointer', border: 'none', background: 'none', color: threadMgmtTab === 'active' ? '#3182ce' : '#718096', borderBottom: threadMgmtTab === 'active' ? '2px solid #3182ce' : '2px solid transparent', marginBottom: -2 }}
+                onClick={() => { setThreadMgmtTab('active'); setThreadMgmtPage(1); }}
+              >🟢 진행중</button>
+              <button
+                style={{ padding: '8px 16px', fontSize: 13, fontWeight: threadMgmtTab === 'closed' ? 600 : 400, cursor: 'pointer', border: 'none', background: 'none', color: threadMgmtTab === 'closed' ? '#e53e3e' : '#718096', borderBottom: threadMgmtTab === 'closed' ? '2px solid #e53e3e' : '2px solid transparent', marginBottom: -2 }}
+                onClick={() => { setThreadMgmtTab('closed'); setThreadMgmtPage(1); }}
+              >🔴 종료</button>
+              <button
+                style={{ padding: '8px 16px', fontSize: 13, fontWeight: threadMgmtTab === 'tokenRequests' ? 600 : 400, cursor: 'pointer', border: 'none', background: 'none', color: threadMgmtTab === 'tokenRequests' ? '#d69e2e' : '#718096', borderBottom: threadMgmtTab === 'tokenRequests' ? '2px solid #d69e2e' : '2px solid transparent', marginBottom: -2 }}
+                onClick={() => setThreadMgmtTab('tokenRequests')}
+              >🎫 발언권 요청 {requestedThreads.length > 0 && `(${requestedThreads.length})`}</button>
+            </div>
+
+            {/* 발언권 요청 탭 콘텐츠 */}
+            {threadMgmtTab === 'tokenRequests' ? (
+              <div>
+                {requestedThreads.length === 0 ? (
+                  <div style={{ color: '#a0aec0', fontSize: 13 }}>발언권 요청이 없습니다</div>
+                ) : requestedThreads.map((item: any) => (
+                  <div key={item.discussion.id} style={{ padding: '12px 0', borderBottom: '1px solid #f0f0f0' }}>
+                    <div style={{ fontSize: 14, fontWeight: 500, color: '#2d3748', marginBottom: 8 }}>
+                      {item.discussion.title}
+                      {item.discussion.status === 'closed' && <span style={{ fontSize: 11, backgroundColor: '#fed7d7', color: '#c53030', padding: '2px 6px', borderRadius: 10, marginLeft: 6 }}>종료</span>}
                     </div>
-                    <div style={{ fontSize: 12, color: '#a0aec0', marginTop: 2 }}>
-                      종료일: {d.endDate ? new Date(d.endDate).toLocaleDateString() : '없음'}
-                    </div>
-                  </div>
-                  <div style={{ display: 'flex', gap: 4 }}>
-                    <button style={{ ...styles.btn, ...styles.btnSecondary, padding: '4px 8px', fontSize: 11 }} onClick={() => handleUpdateEndDate(d.id)}>종료일 수정</button>
-                    {d.isPinned ? (
-                      <button style={{ ...styles.btn, ...styles.btnSecondary, padding: '4px 8px', fontSize: 11 }} onClick={() => handleUnpinThread(d.id)}>대표 해제</button>
-                    ) : (
-                      <button style={{ ...styles.btn, ...styles.btnPrimary, padding: '4px 8px', fontSize: 11 }} onClick={() => handlePinThread(d.id)}>대표 설정</button>
-                    )}
-                    <button style={{ ...styles.btn, ...styles.btnSecondary, padding: '4px 8px', fontSize: 11 }} onClick={() => handleViewTokenRequests(d.id)}>🎫 발언권</button>
-                  </div>
-                </div>
-                {editingEndDateId === d.id && (
-                  <div style={{ marginTop: 8, display: 'flex', gap: 8, alignItems: 'center' }}>
-                    <input type="date" style={{ ...styles.input, marginBottom: 0, flex: 1 }} value={editingEndDateValue} onChange={e => setEditingEndDateValue(e.target.value)} />
-                    <button style={{ ...styles.btn, ...styles.btnPrimary, padding: '6px 12px', fontSize: 12 }} onClick={handleSaveEndDate}>저장</button>
-                    <button style={{ ...styles.btn, ...styles.btnSecondary, padding: '6px 12px', fontSize: 12 }} onClick={() => setEditingEndDateId(null)}>취소</button>
-                  </div>
-                )}
-                {tokenRequestsForId === d.id && (
-                  <div style={{ marginTop: 8, padding: '12px', backgroundColor: '#f7fafc', borderRadius: 6 }}>
-                    <div style={{ fontSize: 12, fontWeight: 600, marginBottom: 8 }}>🎫 발언권 요청 목록</div>
-                    {tokenRequests.length === 0 ? (
-                      <div style={{ fontSize: 12, color: '#a0aec0' }}>요청이 없습니다</div>
-                    ) : tokenRequests.map((req: any) => (
-                      <div key={req.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '4px 0', fontSize: 12 }}>
-                        <span>{req.user.nickname} (남은 발언권: {req.remaining})</span>
-                        <button style={{ ...styles.btn, ...styles.btnPrimary, padding: '2px 8px', fontSize: 11 }} onClick={() => handleGrantTokens(d.id, req.userId)}>+5 지급</button>
+                    {item.requests.map((req: any) => (
+                      <div key={req.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '4px 0 4px 12px', fontSize: 13 }}>
+                        <span>{req.nickname} (남은 발언권: {req.remaining})</span>
+                        <button style={{ ...styles.btn, ...styles.btnPrimary, padding: '2px 8px', fontSize: 11 }} onClick={() => handleGrantTokens(item.discussion.id, req.userId)}>+5 지급</button>
                       </div>
                     ))}
-                    <button style={{ ...styles.btn, ...styles.btnSecondary, padding: '4px 8px', fontSize: 11, marginTop: 8 }} onClick={() => setTokenRequestsForId(null)}>닫기</button>
+                  </div>
+                ))}
+              </div>
+            ) : (
+            <>
+            {/* 정렬 */}
+            <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 12 }}>
+              <select
+                style={{ padding: '4px 10px', fontSize: 12, border: '1px solid #ddd', borderRadius: 4 }}
+                value={currentMgmtSort}
+                onChange={e => {
+                  const v = e.target.value as 'newest' | 'oldest' | 'popular';
+                  if (threadMgmtTab === 'active') setThreadMgmtSort(v);
+                  else setThreadMgmtClosedSort(v);
+                  setThreadMgmtPage(1);
+                }}
+              >
+                <option value="newest">최신순</option>
+                <option value="oldest">오래된순</option>
+                <option value="popular">답글 많은순</option>
+              </select>
+            </div>
+
+            {mgmtSorted.length === 0 ? (
+              <div style={{ color: '#a0aec0', fontSize: 13 }}>{threadMgmtTab === 'active' ? '진행중인 스레드가 없습니다' : '종료된 스레드가 없습니다'}</div>
+            ) : (
+              <>
+                {mgmtPaged.map((d: any) => (
+                  <div key={d.id} style={{ padding: '12px 0', borderBottom: '1px solid #f0f0f0' }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                      <div style={{ flex: 1 }}>
+                        <div style={{ fontSize: 14, fontWeight: 500, color: '#2d3748' }}>
+                          {d.title}
+                          {d.isPinned && <span style={{ fontSize: 11, backgroundColor: '#ebf8ff', color: '#3182ce', padding: '2px 6px', borderRadius: 10, marginLeft: 6 }}>대표</span>}
+                          {d.status === 'closed' && <span style={{ fontSize: 11, backgroundColor: '#fed7d7', color: '#c53030', padding: '2px 6px', borderRadius: 10, marginLeft: 6 }}>종료</span>}
+                          {d.commentCount > 0 && <span style={{ fontSize: 11, color: '#a0aec0', marginLeft: 6 }}>💬 {d.commentCount}</span>}
+                        </div>
+                        <div style={{ fontSize: 12, color: '#a0aec0', marginTop: 2 }}>
+                          종료일: {d.endDate ? new Date(d.endDate).toLocaleDateString() : '없음'}
+                        </div>
+                      </div>
+                      <div style={{ display: 'flex', gap: 4 }}>
+                        <button style={{ ...styles.btn, ...styles.btnSecondary, padding: '4px 8px', fontSize: 11 }} onClick={() => handleUpdateEndDate(d.id)}>종료일 수정</button>
+                        {d.isPinned ? (
+                          <button style={{ ...styles.btn, ...styles.btnSecondary, padding: '4px 8px', fontSize: 11 }} onClick={() => handleUnpinThread(d.id)}>대표 해제</button>
+                        ) : (
+                          <button style={{ ...styles.btn, ...styles.btnPrimary, padding: '4px 8px', fontSize: 11 }} onClick={() => handlePinThread(d.id)}>대표 설정</button>
+                        )}
+    
+                      </div>
+                    </div>
+                    {editingEndDateId === d.id && (
+                      <div style={{ marginTop: 8, display: 'flex', gap: 8, alignItems: 'center' }}>
+                        <input type="date" style={{ ...styles.input, marginBottom: 0, flex: 1 }} value={editingEndDateValue} onChange={e => setEditingEndDateValue(e.target.value)} />
+                        <button style={{ ...styles.btn, ...styles.btnPrimary, padding: '6px 12px', fontSize: 12 }} onClick={handleSaveEndDate}>저장</button>
+                        <button style={{ ...styles.btn, ...styles.btnSecondary, padding: '6px 12px', fontSize: 12 }} onClick={() => setEditingEndDateId(null)}>취소</button>
+                      </div>
+                    )}
+                  </div>
+                ))}
+
+                {/* 페이지네이션 */}
+                {mgmtTotalPages > 1 && (
+                  <div style={{ display: 'flex', justifyContent: 'center', gap: 8, marginTop: 16 }}>
+                    {Array.from({ length: mgmtTotalPages }, (_, i) => i + 1).map(p => (
+                      <button
+                        key={p}
+                        style={{ padding: '4px 10px', fontSize: 12, border: '1px solid #ddd', borderRadius: 4, backgroundColor: p === threadMgmtPage ? '#3182ce' : '#fff', color: p === threadMgmtPage ? '#fff' : '#333', cursor: 'pointer' }}
+                        onClick={() => setThreadMgmtPage(p)}
+                      >{p}</button>
+                    ))}
                   </div>
                 )}
-              </div>
-            ))}
+              </>
+            )}
+            </>
+            )}
           </div>
         );
     }
@@ -403,6 +464,43 @@ function DashboardPage() {
 
       {/* 탭 콘텐츠 */}
       {renderTabContent()}
+
+      {/* 강퇴 확인 모달 */}
+      {kickTarget && (
+        <div style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 }} onClick={() => setKickTarget(null)}>
+          <div style={{ backgroundColor: '#fff', borderRadius: 12, padding: 28, width: 400, maxWidth: '90%', boxShadow: '0 20px 60px rgba(0,0,0,0.2)' }} onClick={e => e.stopPropagation()}>
+            <div style={{ fontSize: 18, fontWeight: 700, color: '#e53e3e', marginBottom: 12 }}>⚠️ 멤버 강제 퇴장</div>
+            <div style={{ fontSize: 14, color: '#4a5568', lineHeight: 1.6, marginBottom: 16 }}>
+              퇴장된 멤버는 모임 재참여가 불가능합니다.<br/>
+              정말로 <strong>{kickTarget.nickname}</strong>님을 강제 퇴장시키겠습니까?
+            </div>
+            <div style={{ fontSize: 13, color: '#718096', marginBottom: 8 }}>진행하려면 <strong>"강제 퇴장"</strong>을 입력하세요.</div>
+            <input
+              type="text"
+              style={{ ...styles.input, marginBottom: 16 }}
+              value={kickInput}
+              onChange={e => setKickInput(e.target.value)}
+              placeholder="강제 퇴장"
+              onKeyDown={e => e.key === 'Enter' && confirmKick()}
+            />
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+              <button style={{ ...styles.btn, ...styles.btnSecondary }} onClick={() => setKickTarget(null)}>취소</button>
+              <button style={{ ...styles.btn, ...styles.btnDanger }} onClick={confirmKick}>진행</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 알림 모달 */}
+      {alertMessage && (
+        <div style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 }} onClick={() => setAlertMessage(null)}>
+          <div style={{ backgroundColor: '#fff', borderRadius: 12, padding: 28, width: 380, maxWidth: '90%', boxShadow: '0 20px 60px rgba(0,0,0,0.2)', textAlign: 'center' }} onClick={e => e.stopPropagation()}>
+            <div style={{ fontSize: 36, marginBottom: 12 }}>⚠️</div>
+            <div style={{ fontSize: 15, color: '#2d3748', lineHeight: 1.6, marginBottom: 20 }}>{alertMessage}</div>
+            <button style={{ ...styles.btn, ...styles.btnPrimary, padding: '8px 24px' }} onClick={() => setAlertMessage(null)}>확인</button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/server/src/routes/token.routes.ts
+++ b/server/src/routes/token.routes.ts
@@ -66,4 +66,18 @@ router.post('/discussions/:id/tokens/grant', authMiddleware, async (req: AuthReq
   }
 });
 
+// GET /api/groups/:groupId/tokens/requested-threads - 발언권 요청이 있는 스레드 목록 (모임장)
+router.get('/groups/:groupId/tokens/requested-threads', authMiddleware, async (req: AuthRequest, res: Response) => {
+  try {
+    const result = await tokenService.listRequestedThreads(req.params.groupId as string, req.user!.userId);
+    res.json(result);
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: { code: err.code, message: err.message } });
+      return;
+    }
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: '서버 오류가 발생했습니다' } });
+  }
+});
+
 export default router;

--- a/server/src/services/token.service.ts
+++ b/server/src/services/token.service.ts
@@ -81,4 +81,34 @@ export const tokenService = {
       include: { user: { select: { id: true, nickname: true } } },
     });
   },
+
+  // 그룹 전체에서 발언권 요청이 있는 스레드 목록 (모임장용)
+  async listRequestedThreads(groupId: string, ownerId: string) {
+    const group = await prisma.group.findUnique({ where: { id: groupId } });
+    if (!group || group.ownerId !== ownerId) {
+      throw new AppError(403, 'FORBIDDEN', '방장만 조회할 수 있습니다');
+    }
+
+    const tokens = await prisma.discussionToken.findMany({
+      where: {
+        requested: true,
+        discussion: { groupId },
+      },
+      include: {
+        user: { select: { id: true, nickname: true } },
+        discussion: { select: { id: true, title: true, status: true } },
+      },
+    });
+
+    // 스레드별로 그룹핑
+    const grouped: Record<string, { discussion: any; requests: any[] }> = {};
+    for (const t of tokens) {
+      if (!grouped[t.discussionId]) {
+        grouped[t.discussionId] = { discussion: t.discussion, requests: [] };
+      }
+      grouped[t.discussionId].requests.push({ id: t.id, userId: t.userId, nickname: t.user.nickname, remaining: t.remaining });
+    }
+
+    return Object.values(grouped);
+  },
 };


### PR DESCRIPTION
## 📝 PR 요약

모임장 대시보드의 UX를 전반적으로 개선합니다.

- 불필요한 모임 일정 탭 삭제
- 탭 순서 변경 (스레드 관리 → 공지사항 → 멤버 관리 → 초대 링크)
- 스레드 관리에 진행중/종료/발언권 요청 서브탭 + 페이지네이션 + 정렬 토글
- 멤버 강퇴 시 커스텀 모달 (경고 + "강제 퇴장" 입력 확인)
- 대표 스레드 초과 시 커스텀 알림 모달
- 발언권 요청 전용 탭 (그룹 전체 요청 한눈에 확인/지급)
- 각 탭에 기능 설명 텍스트 추가
- 초대 링크 만료 중복 표시 제거
- "삭제" → "강퇴" 버튼 텍스트 변경

## 🔗 관련 이슈

- Resolves: #81

## 🏷️ PR 분류

- [x] ✨ 새로운 기능 추가 (New Feature)
- [x] 🛠️ 코드 리팩토링 (Refactoring)

## 🧪 테스트 방법

1. 모임장으로 대시보드 접속 → 탭 순서 확인 (스레드 관리가 첫 번째)
2. 스레드 관리 → 진행중/종료 탭 전환, 정렬 변경, 페이지네이션 확인
3. 발언권 요청 탭 → 요청이 있는 스레드 목록 확인, +5 지급 확인
4. 멤버 관리 → "강퇴" 클릭 → 커스텀 모달에서 "강제 퇴장" 입력 → 진행
5. 대표 설정 3개 후 4번째 시도 → 커스텀 알림 모달 확인
6. 초대 링크 탭 → 만료 시간에 "(생성 후 30분)" 없는지 확인
7. 각 탭 상단 설명 텍스트 확인

## 📸 스크린샷 또는 GIF (선택 사항)
<!-- UI 변경 사항이나 시각적으로 확인할 수 있는 결과물이 있다면 첨부해 주세요. -->
<img width="1017" height="840" alt="image" src="https://github.com/user-attachments/assets/cf68932c-0f5e-48d2-bac4-9fbd82d5bc0b" />
<img width="1146" height="551" alt="image" src="https://github.com/user-attachments/assets/761b2ecd-ef34-4bb1-bb70-f6b4130ad26b" />
