### PR TITLE
feat: 스레드 종료일을 독서기간 내로 제한

### DIFF
--- a/client/src/pages/DiscussionsPage.tsx
+++ b/client/src/pages/DiscussionsPage.tsx
@@ -425,6 +425,11 @@ function DiscussionsPage() {
     if (!formTitle.trim()) errs.title = '제목을 입력해주세요';
     if (!formContent.trim()) errs.content = '내용을 입력해주세요';
     if (!formEndDate) errs.endDate = '종료일을 입력해주세요';
+    if (formEndDate && groupInfo?.readingEndDate) {
+      const endDate = new Date(formEndDate);
+      const readingEnd = new Date(groupInfo.readingEndDate);
+      if (endDate > readingEnd) errs.endDate = '종료일은 독서기간 종료일을 초과할 수 없습니다';
+    }
     setFormErrors(errs);
     if (Object.keys(errs).length > 0) return;
     if (!groupId) return;
@@ -850,10 +855,14 @@ function DiscussionsPage() {
                   <input
                     type="date"
                     min={new Date().toISOString().split('T')[0]}
+                    max={groupInfo?.readingEndDate ? new Date(groupInfo.readingEndDate).toISOString().split('T')[0] : undefined}
                     style={{ ...styles.input, ...(formErrors.endDate ? styles.inputError : {}) }}
                     value={formEndDate}
                     onChange={(e) => setFormEndDate(e.target.value)}
                   />
+                  {groupInfo?.readingEndDate && (
+                    <div style={styles.helpText}>독서기간 종료일({new Date(groupInfo.readingEndDate).toLocaleDateString()})까지 설정 가능</div>
+                  )}
                   {formErrors.endDate && <div style={styles.errorText}>{formErrors.endDate}</div>}
                 </div>
 
@@ -944,7 +953,10 @@ function DiscussionsPage() {
               </div>
               <div style={{ marginBottom: 14 }}>
                 <label style={{ display: 'block', fontSize: 13, fontWeight: 600, marginBottom: 4 }}>종료일</label>
-                <input type="date" min={new Date().toISOString().split('T')[0]} value={editEndDate} onChange={(e) => setEditEndDate(e.target.value)} style={styles.input} />
+                <input type="date" min={new Date().toISOString().split('T')[0]} max={groupInfo?.readingEndDate ? new Date(groupInfo.readingEndDate).toISOString().split('T')[0] : undefined} value={editEndDate} onChange={(e) => setEditEndDate(e.target.value)} style={styles.input} />
+                {groupInfo?.readingEndDate && (
+                  <div style={styles.helpText}>독서기간 종료일({new Date(groupInfo.readingEndDate).toLocaleDateString()})까지 설정 가능</div>
+                )}
               </div>
               <button onClick={handleEditSubmit} disabled={editSaving} style={styles.button}>
                 {editSaving ? '저장 중...' : '수정 완료'}

--- a/server/src/services/discussion.service.ts
+++ b/server/src/services/discussion.service.ts
@@ -43,6 +43,17 @@ export const discussionService = {
       }
     }
 
+    // 종료일이 독서기간을 초과하는지 검증
+    if (data.endDate) {
+      const endDate = new Date(data.endDate);
+      endDate.setHours(23, 59, 59, 999);
+      const readingEnd = new Date(member.group.readingEndDate);
+      readingEnd.setHours(23, 59, 59, 999);
+      if (endDate > readingEnd) {
+        throw new AppError(400, 'END_DATE_EXCEEDS_READING_PERIOD', '스레드 종료일은 독서기간 종료일을 초과할 수 없습니다');
+      }
+    }
+
     const discussion = await prisma.discussion.create({
       data: {
         groupId,
@@ -445,6 +456,11 @@ export const discussionService = {
     if (data.endDate) {
       const endDate = new Date(data.endDate);
       endDate.setHours(23, 59, 59, 999);
+      const readingEnd = new Date(discussion.group.readingEndDate);
+      readingEnd.setHours(23, 59, 59, 999);
+      if (endDate > readingEnd) {
+        throw new AppError(400, 'END_DATE_EXCEEDS_READING_PERIOD', '스레드 종료일은 독서기간 종료일을 초과할 수 없습니다');
+      }
       updateData.endDate = endDate;
       updateData.status = endDate >= new Date() ? 'active' : 'closed';
     }


### PR DESCRIPTION
## 📝 PR 요약
<!-- 이 PR의 목적과 주요 변경 사항을 간략하게 설명해 주세요. -->
스레드 종료일을 독서기간 종료일 이내로만 설정할 수 있도록 제한합니다.

- 서버: 스레드 생성/수정 시 endDate가 그룹의 readingEndDate를 초과하면 400 에러 반환
- 클라이언트: 날짜 input에 max 속성 추가 및 폼 제출 시 클라이언트 검증, 안내 텍스트 표시
- 
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 적어주세요. 이슈를 자동으로 닫으려면 'Resolves #이슈번호' 형태로 작성하세요. -->
- Resolves: #90 

## 🏷️ PR 분류
<!-- 해당되는 항목의 [ ] 안에 x를 입력하여 [x]로 만들어 주세요. -->
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ✨ 새로운 기능 추가 (New Feature)
- [ ] 🛠️ 코드 리팩토링 (Refactoring)
- [ ] 📚 문서 수정 (Documentation)
- [x] ⚙️ 설정/빌드 환경 수정 (Configuration/Build)
- [ ] 🧹 단순 수정 (기능에 영향을 주지 않는 오타 수정, 포맷팅 등)

## 🧪 테스트 방법
<!-- 변경 사항이 정상적으로 동작하는지 확인하기 위해 진행한 테스트 방법과 결과를 설명해 주세요. -->
1. 모임의 독서기간 종료일 이후 날짜로 스레드 종료일 설정 시도
- 클라이언트: date input에서 독서기간 이후 날짜 선택 불가 확인
- 서버: API 직접 호출 시 END_DATE_EXCEEDS_READING_PERIOD 에러 반환 확인
2. 독서기간 내 날짜로 스레드 생성/수정 → 정상 동작 확인
3. 스레드 수정 모달에서도 동일하게 max 제한 및 안내 텍스트 표시 확인
## 📸 스크린샷 또는 GIF (선택 사항)
<!-- UI 변경 사항이나 시각적으로 확인할 수 있는 결과물이 있다면 첨부해 주세요. -->
<img width="597" height="391" alt="image" src="https://github.com/user-attachments/assets/2c00e02b-308a-4665-ae0f-0ddaef8edfc0" />
