### PR TITLE
feat: 종료된 모임에 회고 생성 안내 배너 추가

### DIFF
--- a/client/src/pages/MyPage.tsx
+++ b/client/src/pages/MyPage.tsx
@@ -287,6 +287,20 @@ function MyPage() {
                       ) : null}
                     </div>
                   )}
+                  {/* 종료된 모임 회고 안내 */}
+                  {new Date(g.readingEndDate) < new Date() && !generatedGroups.has(g.id) && insightGroupId !== g.id && (
+                    <div style={{
+                      padding: '10px 14px',
+                      backgroundColor: '#faf5ff',
+                      border: '1px solid #e9d8fd',
+                      borderRadius: 8,
+                      marginBottom: 8,
+                    }}>
+                      <div style={{ fontSize: 13, color: '#553c9a' }}>
+                        📝 모임이 종료되었어요! 회고를 생성해보세요.
+                      </div>
+                    </div>
+                  )}
                 </div>
               );
             })}


### PR DESCRIPTION
## 📝 PR 요약
<!-- 이 PR의 목적과 주요 변경 사항을 간략하게 설명해 주세요. -->
마이페이지에 종료된 모임 아래에 회고 생성 안내 배너를 추가함.
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 적어주세요. 이슈를 자동으로 닫으려면 'Resolves #이슈번호' 형태로 작성하세요. -->
- Resolves: #96

## 🏷️ PR 분류
<!-- 해당되는 항목의 [ ] 안에 x를 입력하여 [x]로 만들어 주세요. -->
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ✨ 새로운 기능 추가 (New Feature)
- [ ] 🛠️ 코드 리팩토링 (Refactoring)
- [ ] 📚 문서 수정 (Documentation)
- [ ] ⚙️ 설정/빌드 환경 수정 (Configuration/Build)
- [ ] 🧹 단순 수정 (기능에 영향을 주지 않는 오타 수정, 포맷팅 등)

## 🧪 테스트 방법
<!-- 변경 사항이 정상적으로 동작하는지 확인하기 위해 진행한 테스트 방법과 결과를 설명해 주세요. -->
마이페이지에 접속 시 종료일이 지난 종료된 모임 아래에 "모임이 종료되었어요! 회고를 생성해보세요." 배너가 뜸.
## 📸 스크린샷 또는 GIF (선택 사항)
<!-- UI 변경 사항이나 시각적으로 확인할 수 있는 결과물이 있다면 첨부해 주세요. -->
