### PR TITLE
114 bug 독서모임기간 제한

### DIFF
--- a/client/src/components/DateRangePicker.tsx
+++ b/client/src/components/DateRangePicker.tsx
@@ -1,0 +1,148 @@
+import { useState } from 'react';
+
+interface DateRangePickerProps {
+  startDate: string;
+  endDate: string;
+  onChangeStart: (date: string) => void;
+  onChangeEnd: (date: string) => void;
+  minDate?: string;
+  startError?: string;
+  endError?: string;
+}
+
+function DateRangePicker({ startDate, endDate, onChangeStart, onChangeEnd, minDate, startError, endError }: DateRangePickerProps) {
+  const today: string = minDate ?? new Date().toISOString().split('T')[0]!;
+  const [viewDate, setViewDate] = useState(() => {
+    if (startDate) return new Date(startDate + 'T00:00:00');
+    return new Date();
+  });
+  const [selecting, setSelecting] = useState<'start' | 'end'>(startDate ? 'end' : 'start');
+
+  const year = viewDate.getFullYear();
+  const month = viewDate.getMonth();
+
+  const firstDay = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+  const prevMonth = () => setViewDate(new Date(year, month - 1, 1));
+  const nextMonth = () => setViewDate(new Date(year, month + 1, 1));
+
+  const formatDate = (y: number, m: number, d: number) => {
+    return `${y}-${String(m + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+  };
+
+  const handleDayClick = (day: number) => {
+    const dateStr = formatDate(year, month, day);
+    if (dateStr < today) return;
+
+    if (selecting === 'start') {
+      onChangeStart(dateStr);
+      if (endDate && dateStr > endDate) onChangeEnd('');
+      setSelecting('end');
+    } else {
+      if (dateStr < startDate) {
+        onChangeStart(dateStr);
+        onChangeEnd('');
+        setSelecting('end');
+      } else {
+        onChangeEnd(dateStr);
+        setSelecting('start');
+      }
+    }
+  };
+
+  const isInRange = (day: number) => {
+    if (!startDate || !endDate) return false;
+    const dateStr = formatDate(year, month, day);
+    return dateStr > startDate && dateStr < endDate;
+  };
+
+  const isStart = (day: number) => formatDate(year, month, day) === startDate;
+  const isEnd = (day: number) => formatDate(year, month, day) === endDate;
+  const isPast = (day: number) => formatDate(year, month, day) < today;
+
+  const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
+
+  const cells: (number | null)[] = [];
+  for (let i = 0; i < firstDay; i++) cells.push(null);
+  for (let d = 1; d <= daysInMonth; d++) cells.push(d);
+
+  return (
+    <div style={styles.wrapper}>
+      <div style={styles.header}>
+        <button type="button" onClick={prevMonth} style={styles.navBtn}>◀</button>
+        <span style={styles.monthLabel}>{year}년 {month + 1}월</span>
+        <button type="button" onClick={nextMonth} style={styles.navBtn}>▶</button>
+      </div>
+
+      <div style={styles.weekRow}>
+        {weekdays.map(w => <div key={w} style={styles.weekCell}>{w}</div>)}
+      </div>
+
+      <div style={styles.grid}>
+        {cells.map((day, i) => {
+          if (day === null) return <div key={`e-${i}`} style={styles.emptyCell} />;
+          const past = isPast(day);
+          const start = isStart(day);
+          const end = isEnd(day);
+          const inRange = isInRange(day);
+
+          let cellStyle: React.CSSProperties = { ...styles.dayCell };
+          if (past) cellStyle = { ...cellStyle, ...styles.pastDay };
+          else if (start || end) cellStyle = { ...cellStyle, ...styles.selectedDay };
+          else if (inRange) cellStyle = { ...cellStyle, ...styles.rangeDay };
+
+          return (
+            <div
+              key={day}
+              style={cellStyle}
+              onClick={() => !past && handleDayClick(day)}
+              role="button"
+              tabIndex={past ? -1 : 0}
+              onKeyDown={(e) => e.key === 'Enter' && !past && handleDayClick(day)}
+            >
+              {day}
+            </div>
+          );
+        })}
+      </div>
+
+      <div style={styles.legend}>
+        <div style={styles.legendItem}>
+          <span style={{ ...styles.legendDot, backgroundColor: '#3182ce' }} />
+          <span>시작일: {startDate || '선택해주세요'}</span>
+        </div>
+        <div style={styles.legendItem}>
+          <span style={{ ...styles.legendDot, backgroundColor: '#e53e3e' }} />
+          <span>종료일: {endDate || '선택해주세요'}</span>
+        </div>
+      </div>
+      <div style={{ fontSize: 12, color: '#718096', textAlign: 'center', marginTop: 4 }}>
+        {selecting === 'start' ? '시작일을 선택하세요' : '종료일을 선택하세요'}
+      </div>
+      {startError && <div style={styles.error}>{startError}</div>}
+      {endError && <div style={styles.error}>{endError}</div>}
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  wrapper: { border: '1px solid #e2e8f0', borderRadius: 8, padding: 12, backgroundColor: '#fff', maxWidth: 320 },
+  header: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 },
+  navBtn: { background: 'none', border: 'none', fontSize: 14, cursor: 'pointer', padding: '2px 6px', color: '#4a5568' },
+  monthLabel: { fontSize: 13, fontWeight: 600, color: '#2d3748' },
+  weekRow: { display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 1, marginBottom: 2 },
+  weekCell: { textAlign: 'center' as const, fontSize: 11, color: '#a0aec0', fontWeight: 600, padding: '2px 0' },
+  grid: { display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 1 },
+  emptyCell: { padding: 6 },
+  dayCell: { textAlign: 'center' as const, padding: '6px 2px', fontSize: 12, borderRadius: 4, cursor: 'pointer', transition: 'background 0.15s' },
+  pastDay: { color: '#cbd5e0', cursor: 'default' },
+  selectedDay: { backgroundColor: '#3182ce', color: '#fff', fontWeight: 700 },
+  rangeDay: { backgroundColor: '#bee3f8', color: '#2b6cb0' },
+  legend: { display: 'flex', justifyContent: 'center', gap: 16, marginTop: 8, fontSize: 12, color: '#4a5568' },
+  legendItem: { display: 'flex', alignItems: 'center', gap: 4 },
+  legendDot: { width: 8, height: 8, borderRadius: '50%', display: 'inline-block' },
+  error: { color: '#e53e3e', fontSize: 11, marginTop: 4, textAlign: 'center' as const },
+};
+
+export default DateRangePicker;

--- a/client/src/pages/CreateGroupPage.tsx
+++ b/client/src/pages/CreateGroupPage.tsx
@@ -6,6 +6,7 @@ import type { BookSearchResult, ApiError } from '../types';
 import { AxiosError } from 'axios';
 import TagInput from '../components/TagInput';
 import PageHeader from '../components/PageHeader';
+import DateRangePicker from '../components/DateRangePicker';
 
 const styles: Record<string, React.CSSProperties> = {
   container: {
@@ -234,7 +235,14 @@ function CreateGroupPage() {
     if (!name.trim()) errs.name = '모임명을 입력해주세요';
     if (!maxMembers || parseInt(maxMembers) < 1) errs.maxMembers = '모집 인원은 1명 이상이어야 합니다';
     if (!readingStartDate) errs.readingStartDate = '독서 시작일을 선택해주세요';
+    else {
+      const today = new Date().toISOString().split('T')[0];
+      if (readingStartDate < today) errs.readingStartDate = '시작일은 오늘 이후여야 합니다';
+    }
     if (!readingEndDate) errs.readingEndDate = '독서 종료일을 선택해주세요';
+    else if (readingStartDate && readingEndDate < readingStartDate) {
+      errs.readingEndDate = '종료일은 시작일 이후여야 합니다';
+    }
     return errs;
   };
 
@@ -423,27 +431,16 @@ function CreateGroupPage() {
             {errors.maxMembers && <div style={styles.errorText}>{errors.maxMembers}</div>}
           </div>
 
-          <div style={styles.row}>
-            <div style={styles.field}>
-              <label style={styles.label}>독서 시작일 *</label>
-              <input
-                type="date"
-                style={{ ...styles.input, ...(errors.readingStartDate ? styles.inputError : {}) }}
-                value={readingStartDate}
-                onChange={(e) => setReadingStartDate(e.target.value)}
-              />
-              {errors.readingStartDate && <div style={styles.errorText}>{errors.readingStartDate}</div>}
-            </div>
-            <div style={styles.field}>
-              <label style={styles.label}>독서 종료일 *</label>
-              <input
-                type="date"
-                style={{ ...styles.input, ...(errors.readingEndDate ? styles.inputError : {}) }}
-                value={readingEndDate}
-                onChange={(e) => setReadingEndDate(e.target.value)}
-              />
-              {errors.readingEndDate && <div style={styles.errorText}>{errors.readingEndDate}</div>}
-            </div>
+          <div style={styles.field}>
+            <label style={styles.label}>독서 기간 *</label>
+            <DateRangePicker
+              startDate={readingStartDate}
+              endDate={readingEndDate}
+              onChangeStart={setReadingStartDate}
+              onChangeEnd={setReadingEndDate}
+              startError={errors.readingStartDate}
+              endError={errors.readingEndDate}
+            />
           </div>
 
           <div style={styles.field}>

--- a/client/src/pages/GroupDetailPage.tsx
+++ b/client/src/pages/GroupDetailPage.tsx
@@ -7,6 +7,7 @@ import { AxiosError } from 'axios';
 import GroupTags from '../components/GroupTags';
 import TagInput from '../components/TagInput';
 import PageHeader from '../components/PageHeader';
+import DateRangePicker from '../components/DateRangePicker';
 
 const styles: Record<string, React.CSSProperties> = {
   container: {
@@ -387,18 +388,19 @@ function GroupDetailPage() {
               <label style={{ display: 'block', fontSize: 13, fontWeight: 500, marginBottom: 4 }}>태그</label>
               <TagInput tags={editTags} onChange={setEditTags} />
             </div>
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 8, marginBottom: 10 }}>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr', gap: 8, marginBottom: 10 }}>
               <div>
                 <label style={{ display: 'block', fontSize: 13, fontWeight: 500, marginBottom: 4 }}>모집 인원</label>
                 <input type="number" min="1" value={editMaxMembers} onChange={(e) => setEditMaxMembers(e.target.value)} style={{ width: '100%', padding: '8px 10px', fontSize: 14, border: '1px solid #ddd', borderRadius: 4, boxSizing: 'border-box' as const }} />
               </div>
               <div>
-                <label style={{ display: 'block', fontSize: 13, fontWeight: 500, marginBottom: 4 }}>독서 시작일</label>
-                <input type="date" value={editReadingStart} onChange={(e) => setEditReadingStart(e.target.value)} style={{ width: '100%', padding: '8px 10px', fontSize: 14, border: '1px solid #ddd', borderRadius: 4, boxSizing: 'border-box' as const }} />
-              </div>
-              <div>
-                <label style={{ display: 'block', fontSize: 13, fontWeight: 500, marginBottom: 4 }}>독서 종료일</label>
-                <input type="date" value={editReadingEnd} onChange={(e) => setEditReadingEnd(e.target.value)} style={{ width: '100%', padding: '8px 10px', fontSize: 14, border: '1px solid #ddd', borderRadius: 4, boxSizing: 'border-box' as const }} />
+                <label style={{ display: 'block', fontSize: 13, fontWeight: 500, marginBottom: 4 }}>독서 기간</label>
+                <DateRangePicker
+                  startDate={editReadingStart}
+                  endDate={editReadingEnd}
+                  onChangeStart={setEditReadingStart}
+                  onChangeEnd={setEditReadingEnd}
+                />
               </div>
             </div>
             <div style={{ marginBottom: 12 }}>

--- a/client/src/pages/GroupDetailPage.tsx
+++ b/client/src/pages/GroupDetailPage.tsx
@@ -394,13 +394,24 @@ function GroupDetailPage() {
                 <input type="number" min="1" value={editMaxMembers} onChange={(e) => setEditMaxMembers(e.target.value)} style={{ width: '100%', padding: '8px 10px', fontSize: 14, border: '1px solid #ddd', borderRadius: 4, boxSizing: 'border-box' as const }} />
               </div>
               <div>
-                <label style={{ display: 'block', fontSize: 13, fontWeight: 500, marginBottom: 4 }}>독서 기간</label>
-                <DateRangePicker
-                  startDate={editReadingStart}
-                  endDate={editReadingEnd}
-                  onChangeStart={setEditReadingStart}
-                  onChangeEnd={setEditReadingEnd}
-                />
+                <button
+                  type="button"
+                  onClick={() => {
+                    const el = document.getElementById('edit-date-picker');
+                    if (el) el.style.display = el.style.display === 'none' ? 'block' : 'none';
+                  }}
+                  style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13, fontWeight: 500, background: 'none', border: '1px solid #e2e8f0', borderRadius: 6, padding: '8px 12px', cursor: 'pointer', color: '#4a5568', width: '100%' }}
+                >
+                  📅 독서 기간: {editReadingStart && editReadingEnd ? `${editReadingStart} ~ ${editReadingEnd}` : '클릭하여 설정'}
+                </button>
+                <div id="edit-date-picker" style={{ display: 'none', marginTop: 8 }}>
+                  <DateRangePicker
+                    startDate={editReadingStart}
+                    endDate={editReadingEnd}
+                    onChangeStart={setEditReadingStart}
+                    onChangeEnd={setEditReadingEnd}
+                  />
+                </div>
               </div>
             </div>
             <div style={{ marginBottom: 12 }}>

--- a/server/src/services/group.service.ts
+++ b/server/src/services/group.service.ts
@@ -17,6 +17,18 @@ const mapTags = (tags?: { name: string }[]) => tags?.map(tag => tag.name) ?? [];
 
 export const groupService = {
   async create(data: CreateGroupInput, userId: string) {
+    // 날짜 검증: 시작일은 오늘 이후, 종료일은 시작일 이후
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const startDate = new Date(data.readingStartDate);
+    const endDate = new Date(data.readingEndDate);
+    if (startDate < today) {
+      throw new AppError(400, 'VALIDATION_ERROR', '독서 시작일은 오늘 이후여야 합니다');
+    }
+    if (endDate < startDate) {
+      throw new AppError(400, 'VALIDATION_ERROR', '독서 종료일은 시작일 이후여야 합니다');
+    }
+
     // Find or create the Book entity
     let bookId = data.bookId;
 


### PR DESCRIPTION
## 📝 PR 요약
<!-- 이 PR의 목적과 주요 변경 사항을 간략하게 설명해 주세요. -->
독서 모임 생성/수정 시 과거 날짜 선택 및 종료일이 시작일보다 이전인 날짜를 설정할 수 있던 버그를 수정합니다.

- 커스텀 달력(DateRangePicker) 컴포넌트를 만들어 시작일~종료일을 한 달력에서 범위 선택
- 모임 생성: 달력 항상 표시
- 모임 수정: 클릭하여 달력 토글
- 서버에도 날짜 검증 추가 (시작일 < 오늘, 종료일 < 시작일 방어)
- 
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 적어주세요. 이슈를 자동으로 닫으려면 'Resolves #이슈번호' 형태로 작성하세요. -->
- Resolves: #114 

## 🏷️ PR 분류
<!-- 해당되는 항목의 [ ] 안에 x를 입력하여 [x]로 만들어 주세요. -->
- [x] 🐛 버그 수정 (Bug Fix)
- [x] ✨ 새로운 기능 추가 (New Feature)
- [ ] 🛠️ 코드 리팩토링 (Refactoring)
- [ ] 📚 문서 수정 (Documentation)
- [ ] ⚙️ 설정/빌드 환경 수정 (Configuration/Build)
- [ ] 🧹 단순 수정 (기능에 영향을 주지 않는 오타 수정, 포맷팅 등)

## 🧪 테스트 방법
<!-- 변경 사항이 정상적으로 동작하는지 확인하기 위해 진행한 테스트 방법과 결과를 설명해 주세요. -->
모임 생성 페이지에서 달력 UI 확인 → 오늘 이전 날짜 선택 불가(회색 처리)
시작일 선택 후 종료일은 시작일 이후만 선택 가능 확인
시작일 > 종료일 역순 선택 시 자동으로 시작일 재설정 확인
모임 수정 모달에서 "📅 독서 기간" 버튼 클릭 → 달력 토글 동작 확인
서버 API 직접 호출로 과거 날짜 전송 시 400 에러 반환 확인

## 📸 스크린샷 또는 GIF (선택 사항)
<!-- UI 변경 사항이나 시각적으로 확인할 수 있는 결과물이 있다면 첨부해 주세요. -->

