### PR TITLE
fix: 전 페이지 레이아웃 너비 800px로 통일 (홈페이지 960px 유지)

### DIFF
--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -16,7 +16,7 @@ const tabs = [
 type TabId = typeof tabs[number]['id'];
 
 const styles: Record<string, React.CSSProperties> = {
-  container: { maxWidth: 900, margin: '0 auto', padding: '24px 16px' },
+  container: { maxWidth: 800, margin: '0 auto', padding: '24px 16px' },
   backLink: { display: 'inline-block', marginBottom: 16, fontSize: 14, color: '#3182ce' },
   title: { fontSize: 24, fontWeight: 700, marginBottom: 16 },
   tabBar: { display: 'flex', gap: 0, borderBottom: '2px solid #e2e8f0', marginBottom: 20 },

--- a/client/src/pages/NotificationsPage.tsx
+++ b/client/src/pages/NotificationsPage.tsx
@@ -6,7 +6,7 @@ import type { NotificationItem } from '../types';
 
 const styles: Record<string, React.CSSProperties> = {
   container: {
-    maxWidth: 760,
+    maxWidth: 800,
     margin: '0 auto',
     padding: '24px 16px',
   },


### PR DESCRIPTION
## 📝 PR 요약
<!-- 이 PR의 목적과 주요 변경 사항을 간략하게 설명해 주세요. -->
페이지별로 제각각이던 레이아웃 너비를 통일합니다.

DashboardPage: 900 → 800px
NotificationsPage: 760 → 800px
HomePage: 카드 레이아웃 특성상 960px 유지
모임생성페이지는 폼이므로 적은 너비 유지

## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 적어주세요. 이슈를 자동으로 닫으려면 'Resolves #이슈번호' 형태로 작성하세요. -->
- Resolves: #120 

## 🏷️ PR 분류
<!-- 해당되는 항목의 [ ] 안에 x를 입력하여 [x]로 만들어 주세요. -->
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ✨ 새로운 기능 추가 (New Feature)
- [ ] 🛠️ 코드 리팩토링 (Refactoring)
- [ ] 📚 문서 수정 (Documentation)
- [ ] ⚙️ 설정/빌드 환경 수정 (Configuration/Build)
- [ ] 🧹 단순 수정 (기능에 영향을 주지 않는 오타 수정, 포맷팅 등)

## 🧪 테스트 방법
<!-- 변경 사항이 정상적으로 동작하는지 확인하기 위해 진행한 테스트 방법과 결과를 설명해 주세요. -->

## 📸 스크린샷 또는 GIF (선택 사항)
<!-- UI 변경 사항이나 시각적으로 확인할 수 있는 결과물이 있다면 첨부해 주세요. -->
