### PR TITLE
fix: 모임 카드 레이아웃 고정 높이 영역 적용 및 간격 조정

### DIFF
--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -113,16 +113,16 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: 13,
     color: '#718096',
     marginBottom: 12,
-    lineHeight: 1.6,
+    lineHeight: 1.5,
     display: '-webkit-box',
-    WebkitLineClamp: 3,
+    WebkitLineClamp: 2,
     WebkitBoxOrient: 'vertical' as any,
     overflow: 'hidden',
   },
   meta: {
     fontSize: 12,
     color: '#a0aec0',
-    lineHeight: 1.9,
+    lineHeight: 1.6,
   },
   members: {
     display: 'inline-block',
@@ -409,19 +409,23 @@ function HomePage() {
                     style={{ width: 80, minHeight: 110, objectFit: 'contain', borderRadius: 4, flexShrink: 0 }}
                   />
                 )}
-                <div style={{ flex: 1, minWidth: 0, minHeight: 110, display: 'flex', flexDirection: 'column' as const }}>
-                  <div style={styles.bookTitle}>{g.book?.title || '제목 없음'}</div>
-                  <div style={styles.groupName}>{g.name}</div>
-                  <div style={{ marginBottom: 8 }}>
-                    <GroupTags tags={g.tags} compact />
+                <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' as const }}>
+                  <div style={{ ...styles.bookTitle, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const }}>{g.book?.title || '제목 없음'}</div>
+                  <div style={{ ...styles.groupName, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const, marginBottom: 2 }}>{g.name}</div>
+                  <div style={{ height: 20, overflow: 'hidden', marginBottom: 2 }}>
+                    {g.tags && g.tags.length > 0 && <GroupTags tags={g.tags} compact />}
                   </div>
-                  {g.description && <div style={{ ...styles.summary, marginBottom: 8 }}>{g.description}</div>}
-                  <div style={{ marginTop: 'auto' as any }}>
+                  <div style={{ height: 34, overflow: 'hidden', marginBottom: 4, fontSize: 13, color: '#718096', lineHeight: '17px' }}>
+                    {g.description || '\u00A0'}
+                  </div>
+                  <div>
                   <div style={styles.meta}>
-                    📅 독서 기간: {formatDate(g.readingStartDate)} ~ {formatDate(g.readingEndDate)}<br />
+                    <div style={{ marginBottom: 6 }}>📅 독서 기간: {formatDate(g.readingStartDate)} ~ {formatDate(g.readingEndDate)}</div>
+                    <div>
                     {g.ownerNickname && <span style={{ display: 'inline-block', background: '#edf2ff', color: '#4c51bf', padding: '3px 10px', borderRadius: 12, fontSize: 12, fontWeight: 600, marginRight: 6 }}>👤 {g.ownerNickname}</span>}
                     <span style={styles.members}>👥 {g.currentMembers}/{g.maxMembers}명</span>
                     {(g as any).isPrivate && <span style={{ display: 'inline-block', background: '#fefcbf', color: '#975a16', padding: '3px 10px', borderRadius: 12, fontSize: 12, fontWeight: 600, marginLeft: 6 }}>🔒 비공개</span>}
+                    </div>
                   </div>
                   </div>
                 </div>


### PR DESCRIPTION
## 📝 PR 요약
<!-- 이 PR의 목적과 주요 변경 사항을 간략하게 설명해 주세요. -->
메인페이지 모임 카드의 레이아웃을 고정 높이 영역으로 재설정하여, 태그/설명/제목 길이에 관계없이 카드 간 정렬이 일관되도록 수정합니다.

- 제목/모임명: 1줄 고정, 넘치면 ... 처리
- 태그 영역: 20px 고정
- 설명 영역: 34px 고정 (2줄, 넘치면 잘림)
- 독서기간과 방장/인원 사이 간격 추가

## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 적어주세요. 이슈를 자동으로 닫으려면 'Resolves #이슈번호' 형태로 작성하세요. -->
- Resolves: #126 

## 🏷️ PR 분류
<!-- 해당되는 항목의 [ ] 안에 x를 입력하여 [x]로 만들어 주세요. -->
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ✨ 새로운 기능 추가 (New Feature)
- [ ] 🛠️ 코드 리팩토링 (Refactoring)
- [ ] 📚 문서 수정 (Documentation)
- [ ] ⚙️ 설정/빌드 환경 수정 (Configuration/Build)
- [ ] 🧹 단순 수정 (기능에 영향을 주지 않는 오타 수정, 포맷팅 등)

## 🧪 테스트 방법
<!-- 변경 사항이 정상적으로 동작하는지 확인하기 위해 진행한 테스트 방법과 결과를 설명해 주세요. -->

1. 메인페이지에서 태그 있는 모임과 없는 모임이 같은 높이에 독서기간/방장/인원 표시되는지 확인
2. 설명 있는 모임과 없는 모임의 카드 레이아웃 정렬 확인
3. 긴 제목의 모임이 ... 으로 잘리는지 확인
4. 모임 상세 페이지에서 전체 제목/설명이 정상 표시되는지 확인

## 📸 스크린샷 또는 GIF (선택 사항)
<!-- UI 변경 사항이나 시각적으로 확인할 수 있는 결과물이 있다면 첨부해 주세요. -->
<img width="1195" height="565" alt="image" src="https://github.com/user-attachments/assets/0b441943-3d19-4cdc-95b6-94319b4a4887" />
