### PR TITLE
bug: 스레드 종료일 당일 설정 막음

### DIFF
--- a/client/src/pages/DiscussionsPage.tsx
+++ b/client/src/pages/DiscussionsPage.tsx
@@ -855,7 +855,7 @@ function DiscussionsPage() {
                   <label style={styles.label}>종료일 *</label>
                   <input
                     type="date"
-                    min={new Date().toISOString().split('T')[0]}
+                    min={(() => { const d = new Date(); d.setDate(d.getDate() + 1); return d.toISOString().split('T')[0]; })()}
                     max={groupInfo?.readingEndDate ? new Date(groupInfo.readingEndDate).toISOString().split('T')[0] : undefined}
                     style={{ ...styles.input, ...(formErrors.endDate ? styles.inputError : {}) }}
                     value={formEndDate}
@@ -959,7 +959,7 @@ function DiscussionsPage() {
               </div>
               <div style={{ marginBottom: 14 }}>
                 <label style={{ display: 'block', fontSize: 13, fontWeight: 600, marginBottom: 4 }}>종료일</label>
-                <input type="date" min={new Date().toISOString().split('T')[0]} max={groupInfo?.readingEndDate ? new Date(groupInfo.readingEndDate).toISOString().split('T')[0] : undefined} value={editEndDate} onChange={(e) => setEditEndDate(e.target.value)} style={styles.input} />
+                <input type="date" min={(() => { const d = new Date(); d.setDate(d.getDate() + 1); return d.toISOString().split('T')[0]; })()} max={groupInfo?.readingEndDate ? new Date(groupInfo.readingEndDate).toISOString().split('T')[0] : undefined} value={editEndDate} onChange={(e) => setEditEndDate(e.target.value)} style={styles.input} />
                 {groupInfo?.readingEndDate && (
                   <div style={styles.helpText}>독서기간 종료일({new Date(groupInfo.readingEndDate).toLocaleDateString()})까지 설정 가능</div>
                 )}

--- a/server/src/services/discussion.service.ts
+++ b/server/src/services/discussion.service.ts
@@ -56,6 +56,11 @@ export const discussionService = {
     if (data.endDate) {
       const endDate = new Date(data.endDate);
       endDate.setHours(23, 59, 59, 999);
+      const today = new Date();
+      today.setHours(23, 59, 59, 999);
+      if (endDate <= today) {
+        throw new AppError(400, 'END_DATE_TOO_EARLY', '스레드 종료일은 내일 이후로 설정해야 합니다');
+      }
       const readingEnd = new Date(member.group.readingEndDate);
       readingEnd.setHours(23, 59, 59, 999);
       if (endDate > readingEnd) {


### PR DESCRIPTION
## 📝 PR 요약
<!-- 이 PR의 목적과 주요 변경 사항을 간략하게 설명해 주세요. -->
스레드 종료일을 당일로 설정하면 바로 종료되는 버그 발생 
당일로 설정을 하지 못하도록 막음
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 적어주세요. 이슈를 자동으로 닫으려면 'Resolves #이슈번호' 형태로 작성하세요. -->
- Resolves: #132 

## 🏷️ PR 분류
<!-- 해당되는 항목의 [ ] 안에 x를 입력하여 [x]로 만들어 주세요. -->
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ✨ 새로운 기능 추가 (New Feature)
- [ ] 🛠️ 코드 리팩토링 (Refactoring)
- [ ] 📚 문서 수정 (Documentation)
- [ ] ⚙️ 설정/빌드 환경 수정 (Configuration/Build)
- [ ] 🧹 단순 수정 (기능에 영향을 주지 않는 오타 수정, 포맷팅 등)

## 🧪 테스트 방법
<!-- 변경 사항이 정상적으로 동작하는지 확인하기 위해 진행한 테스트 방법과 결과를 설명해 주세요. -->
스레드 생성 시 날짜 선택에 선택할 수 없도록 막아놓음.
## 📸 스크린샷 또는 GIF (선택 사항)
<!-- UI 변경 사항이나 시각적으로 확인할 수 있는 결과물이 있다면 첨부해 주세요. -->
