### PR TITLE
feat: 모임 생성 시 동일 책 사용 모임 안내 (#156)

### DIFF
--- a/client/src/pages/CreateGroupPage.tsx
+++ b/client/src/pages/CreateGroupPage.tsx
@@ -171,6 +171,7 @@ function CreateGroupPage() {
   const [bookQuery, setBookQuery] = useState('');
   const [bookResults, setBookResults] = useState<BookSearchResult[]>([]);
   const [selectedBook, setSelectedBook] = useState<BookSearchResult | null>(null);
+  const [existingGroups, setExistingGroups] = useState<any[]>([]);
   const [manualMode, setManualMode] = useState(false);
   const [searching, setSearching] = useState(false);
 
@@ -208,16 +209,25 @@ function CreateGroupPage() {
     }
   };
 
-  const handleSelectBook = (book: BookSearchResult) => {
+  const handleSelectBook = async (book: BookSearchResult) => {
     setSelectedBook(book);
     setBookTitle(book.title);
     setBookAuthor(book.author);
     setBookSummary(book.summary || '');
     setBookResults([]);
+
+    // 동일 책 사용 모임 조회
+    try {
+      const res = await groupsApi.list({ search: book.title });
+      setExistingGroups(res.data.data || []);
+    } catch {
+      setExistingGroups([]);
+    }
   };
 
   const handleClearBook = () => {
     setSelectedBook(null);
+    setExistingGroups([]);
     setBookTitle('');
     setBookAuthor('');
     setBookSummary('');
@@ -341,6 +351,20 @@ function CreateGroupPage() {
             <div style={styles.selectedBook}>
               <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1, minWidth: 0 }}>✅ {selectedBook.title} — {selectedBook.author}</span>
               <button type="button" style={styles.manualToggle} onClick={handleClearBook}>변경</button>
+            </div>
+          )}
+
+          {/* 동일 책 사용 모임 안내 */}
+          {existingGroups.length > 0 && selectedBook && (
+            <div style={{ backgroundColor: '#fffbeb', border: '1px solid #f6e05e', borderRadius: 8, padding: '12px 16px', marginTop: 12 }}>
+              <div style={{ fontSize: 13, fontWeight: 600, color: '#975a16', marginBottom: 8 }}>📢 이 책으로 진행 중인 모임이 있습니다</div>
+              {existingGroups.slice(0, 3).map((g: any) => (
+                <div key={g.id} style={{ fontSize: 12, color: '#744210', padding: '4px 0', borderBottom: '1px solid #fefcbf' }}>
+                  <strong>{g.name}</strong> — {g.currentMembers}/{g.maxMembers}명 · {new Date(g.readingStartDate).toLocaleDateString()} ~ {new Date(g.readingEndDate).toLocaleDateString()}
+                </div>
+              ))}
+              {existingGroups.length > 3 && <div style={{ fontSize: 11, color: '#975a16', marginTop: 4 }}>외 {existingGroups.length - 3}개 모임</div>}
+              <div style={{ fontSize: 11, color: '#975a16', marginTop: 8 }}>기존 모임에 참여하거나, 새 모임을 만들 수 있습니다.</div>
             </div>
           )}
 


### PR DESCRIPTION
## 📝 PR 요약

모임 생성 시 선택한 책으로 이미 진행 중인 모임이 있으면 안내를 표시합니다.

- 책 선택 시 기존 모임 자동 조회
- 기존 모임이 있으면 노란 안내 박스 표시 (모임명, 인원, 독서 기간)
- 모임 생성을 막지 않고 안내만 제공

## 🔗 관련 이슈

- Resolves: #156

## 🏷️ PR 분류

- [x] ✨ 새로운 기능 추가 (New Feature)

## 🧪 테스트 방법

1. 모임 만들기 페이지 접속
2. 이미 모임이 존재하는 책 제목으로 검색 → 책 선택
3. "📢 이 책으로 진행 중인 모임이 있습니다" 안내 표시 확인
4. 모임명, 참여 인원, 독서 기간 정보 확인
5. "변경" 버튼 클릭 → 안내 사라지는지 확인
6. 모임이 없는 책 선택 → 안내 미표시 확인
7. 안내가 있어도 모임 생성이 정상 진행되는지 확인

## 📸 스크린샷 또는 GIF (선택 사항)
<!-- UI 변경 사항이나 시각적으로 확인
<img width="823" height="323" alt="image" src="https://github.com/user-attachments/assets/be6dc5f1-356b-48e2-95cf-7eae354485af" />
할 수 있는 결과물이 있다면 첨부해 주세요. -->

